### PR TITLE
Fix benchlab-pycore 0.5.1 compatibility + add CI to catch future drift

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -1,0 +1,66 @@
+name: pycore compatibility
+
+# Catches drift between pytools and benchlab-pycore's published PyPI API.
+# See issue #9 — issues #6/#7/#8 were caused by silent drift like this.
+on:
+  push:
+    branches: [dev-pycore, main]
+  pull_request:
+  schedule:
+    # Weekly, to catch a new pycore release even with no pytools code changes.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  pinned:
+    name: Import + test against pinned pycore
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies (pinned)
+        run: |
+          pip install -r requirements.txt
+          pip install -r benchlab/csv_log/requirements.txt
+          pip install pytest
+
+      - name: Import smoke test
+        run: >
+          python -c "import benchlab.core, benchlab.core.discovery,
+          benchlab.core.datasource, benchlab.core.shared_serial,
+          benchlab.config.config_client, benchlab.restapi.telemetry_api,
+          benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export"
+
+      - name: Run non-hardware tests
+        run: pytest tests/test_data_sources.py benchlab/restapi/test_server.py -q -k "not mqtt"
+
+  latest:
+    name: Import + test against latest pycore (PyPI)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies (latest pycore)
+        run: |
+          pip install -r requirements.txt
+          pip install -r benchlab/csv_log/requirements.txt
+          pip install pytest
+          pip install --upgrade benchlab-pycore
+
+      - name: Import smoke test
+        run: >
+          python -c "import benchlab.core, benchlab.core.discovery,
+          benchlab.core.datasource, benchlab.core.shared_serial,
+          benchlab.config.config_client, benchlab.restapi.telemetry_api,
+          benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export"
+
+      - name: Run non-hardware tests
+        run: pytest tests/test_data_sources.py benchlab/restapi/test_server.py -q -k "not mqtt"

--- a/benchlab/config/config_client.py
+++ b/benchlab/config/config_client.py
@@ -298,18 +298,18 @@ class DirectConfigClient(ConfigClient):
     
     def save_config(self) -> bool:
         """Save configuration to device flash."""
-        from benchlab_pycore.core import send_action
-        return send_action(self.ser, action=0)  # CONFIG_ACTION_SAVE
-    
+        from benchlab_pycore.core.config_io import save_config
+        return save_config(self.ser)
+
     def load_config(self) -> bool:
         """Load configuration from device flash."""
-        from benchlab_pycore.core import send_action
-        return send_action(self.ser, action=1)  # CONFIG_ACTION_LOAD
-    
+        from benchlab_pycore.core.config_io import load_config
+        return load_config(self.ser)
+
     def reset_config(self) -> bool:
         """Reset configuration to factory defaults."""
-        from benchlab_pycore.core import send_action
-        return send_action(self.ser, action=2)  # CONFIG_ACTION_RESET
+        from benchlab_pycore.core.config_io import reset_config
+        return reset_config(self.ser)
     
     def close(self):
         """Close serial connection."""

--- a/benchlab/core/__init__.py
+++ b/benchlab/core/__init__.py
@@ -14,6 +14,8 @@ PyCore v0.3.0 Multi-Variant Support:
 - CFE (0x11): 23 power sensors, 8 temperature sensors
 """
 
+import logging
+
 from benchlab.core.datasource import (
     DataSource,
     DirectDataSource,
@@ -30,15 +32,21 @@ from benchlab.core.statistics import (
     create_stats_callback,
 )
 
-# PyCore v0.3.0 variant constants for tools that need to detect device capabilities
-# Import from pycore to make them easily accessible to tools
+logger = logging.getLogger("benchlab.core")
+
+# PyCore variant constants for tools that need to detect device capabilities
+# Import from pycore to make them easily accessible to tools.
+# PyCore >=0.4.1 renamed BENCHLAB_CFE_PRODUCT_ID to BENCHLAB_BL2_PRODUCT_ID;
+# BENCHLAB_CFE_PRODUCT_ID is kept here as a local alias so the rest of this
+# repo doesn't need to rename all at once.
 try:
-    from benchlab_pycore.core import (
-        BENCHLAB_ORIGINAL_PRODUCT_ID,
-        BENCHLAB_CFE_PRODUCT_ID,
-    )
+    from benchlab_pycore.core import BENCHLAB_ORIGINAL_PRODUCT_ID
+    try:
+        from benchlab_pycore.core import BENCHLAB_BL2_PRODUCT_ID as BENCHLAB_CFE_PRODUCT_ID
+    except ImportError:
+        from benchlab_pycore.core import BENCHLAB_CFE_PRODUCT_ID
 except ImportError:
-    # Fallback defaults if pycore not installed
+    logger.warning("benchlab_pycore not installed; using fallback product ID constants")
     BENCHLAB_ORIGINAL_PRODUCT_ID = 0x10
     BENCHLAB_CFE_PRODUCT_ID = 0x11
 

--- a/benchlab/core/datasource.py
+++ b/benchlab/core/datasource.py
@@ -128,11 +128,17 @@ class DirectDataSource(DataSource):
         # Import pycore
         try:
             from benchlab_pycore.core import (
-                read_sensors, read_device, read_uid, 
+                read_sensors, read_device, read_uid,
                 translate_sensor_struct, get_benchlab_ports,
-                BENCHLAB_ORIGINAL_PRODUCT_ID, BENCHLAB_CFE_PRODUCT_ID
+                BENCHLAB_ORIGINAL_PRODUCT_ID,
             )
-            from benchlab_pycore.core.serial_io import open_serial_connection
+            try:
+                from benchlab_pycore.core import BENCHLAB_BL2_PRODUCT_ID as BENCHLAB_CFE_PRODUCT_ID
+            except ImportError:
+                from benchlab_pycore.core import BENCHLAB_CFE_PRODUCT_ID
+            # benchlab_pycore.core.serial_io has no connection-opening helper;
+            # use the local wrapper instead (see benchlab.core.shared_serial).
+            from benchlab.core.shared_serial import open_serial_connection
             self._pycore = {
                 'read_sensors': read_sensors,
                 'read_device': read_device,

--- a/benchlab/core/discovery.py
+++ b/benchlab/core/discovery.py
@@ -12,9 +12,21 @@ import logging
 from typing import List, Dict, Any
 
 # benchlab-pycore helpers
-from benchlab_pycore.core import get_benchlab_ports, BENCHLAB_ORIGINAL_PRODUCT_ID, BENCHLAB_CFE_PRODUCT_ID
-from benchlab_pycore.core.serial_io import open_serial_connection
+from benchlab_pycore.core import get_benchlab_ports
 from benchlab_pycore.core import read_device, read_uid
+
+# benchlab_pycore.core.serial_io has no connection-opening helper; use the
+# local wrapper instead (see benchlab.core.shared_serial for why).
+from benchlab.core.shared_serial import open_serial_connection
+
+# PyCore >=0.4.1 renamed BENCHLAB_CFE_PRODUCT_ID to BENCHLAB_BL2_PRODUCT_ID.
+# Imported directly from pycore (not from benchlab.core) to avoid a circular
+# import, since benchlab.core imports this module via datasource_manager.
+try:
+    from benchlab_pycore.core import BENCHLAB_BL2_PRODUCT_ID as BENCHLAB_CFE_PRODUCT_ID
+except ImportError:
+    from benchlab_pycore.core import BENCHLAB_CFE_PRODUCT_ID
+from benchlab_pycore.core import BENCHLAB_ORIGINAL_PRODUCT_ID
 
 # Re‑use the retry decorator defined in ``benchlab.core.retry``
 from .retry import retry, RetryPolicy

--- a/benchlab/core/shared_serial.py
+++ b/benchlab/core/shared_serial.py
@@ -11,7 +11,29 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
+import serial
+
 logger = logging.getLogger("benchlab.core.shared_serial")
+
+# BENCHLAB devices communicate over USB CDC at a fixed 115200 baud.
+# benchlab_pycore.core.serial_io never exposed a connection-opening helper
+# (its own docs just call serial.Serial(port, 115200, timeout=1) directly) —
+# this wraps that same pattern so callers get a consistent
+# "None on failure" contract instead of talking to pyserial directly.
+_BENCHLAB_BAUDRATE = 115200
+_BENCHLAB_TIMEOUT = 1
+
+
+def open_serial_connection(port: str) -> Optional[serial.Serial]:
+    """Open a serial connection to a BENCHLAB device.
+
+    Returns None if the port can't be opened.
+    """
+    try:
+        return serial.Serial(port, _BENCHLAB_BAUDRATE, timeout=_BENCHLAB_TIMEOUT)
+    except (serial.SerialException, OSError) as e:
+        logger.warning("Failed to open serial port %s: %s", port, e)
+        return None
 
 
 class SharedSerialManager:
@@ -70,12 +92,7 @@ class SharedSerialManager:
             SharedConnection wrapper, or None if port can't be opened
         """
         if open_func is None:
-            try:
-                from benchlab_pycore.core.serial_io import open_serial_connection
-                open_func = open_serial_connection
-            except ImportError:
-                logger.error("Cannot import open_serial_connection")
-                return None
+            open_func = open_serial_connection
         
         start = time.time()
         while time.time() - start < timeout:

--- a/benchlab/csv_log/requirements.txt
+++ b/benchlab/csv_log/requirements.txt
@@ -1,3 +1,3 @@
 # benchlab/csv_log/requirements.txt
 pyserial>=3.5
-benchlab-pycore>=0.1.1
+benchlab-pycore>=0.5.1

--- a/benchlab/hwinfo/hwinfo_export.py
+++ b/benchlab/hwinfo/hwinfo_export.py
@@ -164,7 +164,7 @@ def export_device_sensors(device_info, datasource=None):
         # Fallback: direct probe via pycore (legacy behavior)
         try:
             from benchlab_pycore.core import read_sensors
-            from benchlab_pycore.core.serial_io import open_serial_connection
+            from benchlab.core.shared_serial import open_serial_connection
             ser = open_serial_connection(port)
             if not ser:
                 logger.error("Cannot open serial port for device %s", uid)

--- a/benchlab/mqtt/mqtt_publisher.py
+++ b/benchlab/mqtt/mqtt_publisher.py
@@ -12,10 +12,13 @@ import threading
 import time
 
 from benchlab_pycore.core import translate_sensor_struct, read_sensors, read_device, BENCHLAB_ORIGINAL_PRODUCT_ID
-from benchlab_pycore.core.serial_io import get_fleet_info, open_serial_connection
+from benchlab_pycore.core.serial_io import get_fleet_info
 
 # Import DeviceRegistry so the MQTT publisher publishes device lifecycle events
 from benchlab.core.device_registry import DeviceRegistry
+# benchlab_pycore.core.serial_io has no connection-opening helper; use the
+# local wrapper instead (see benchlab.core.shared_serial).
+from benchlab.core.shared_serial import open_serial_connection
 
 MQTTV5_REASON_CODES = {
     0:  "Success",

--- a/benchlab/restapi/telemetry_api.py
+++ b/benchlab/restapi/telemetry_api.py
@@ -14,8 +14,12 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from pathlib import Path
 
-from benchlab_pycore.core import read_sensors, read_device, read_uid, translate_sensor_struct, BENCHLAB_ORIGINAL_PRODUCT_ID, BENCHLAB_CFE_PRODUCT_ID
-from benchlab_pycore.core.serial_io import get_fleet_info, open_serial_connection
+from benchlab_pycore.core import read_sensors, read_device, read_uid, translate_sensor_struct
+from benchlab_pycore.core.serial_io import get_fleet_info
+from benchlab.core import BENCHLAB_ORIGINAL_PRODUCT_ID, BENCHLAB_CFE_PRODUCT_ID
+# benchlab_pycore.core.serial_io has no connection-opening helper; use the
+# local wrapper instead (see benchlab.core.shared_serial).
+from benchlab.core.shared_serial import open_serial_connection
 
 # Import DeviceRegistry so the FastAPI server publishes device lifecycle events
 from benchlab.core.device_registry import DeviceRegistry

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ packaging>=23.0,<26.0
 python-dotenv>=1.0.0,<2.0
 
 # BENCHLAB Serial Handler
-benchlab-pycore>=0.3.0
+benchlab-pycore>=0.5.1
 
 # FastAPI Data Source
 fastapi==0.111.1


### PR DESCRIPTION
## Summary

- Fixes three compatibility bugs found between pytools and `benchlab-pycore` 0.5.1 (root cause: pytools was pinned to `>=0.3.0` and had never been checked against the API pycore actually ships now):
  - `BENCHLAB_CFE_PRODUCT_ID` renamed to `BENCHLAB_BL2_PRODUCT_ID` in pycore >=0.4.1 — several unguarded imports would `ImportError`
  - `DirectConfigClient.save_config/load_config/reset_config` were using the wrong wire command (`UART_CMD_ACTION` instead of pycore's dedicated `UART_CMD_NVM_CONFIG`-based functions)
  - `open_serial_connection` was imported from `benchlab_pycore.core.serial_io` across 6 modules but never actually existed there — added a small local wrapper in `benchlab.core.shared_serial` instead
- Adds `.github/workflows/pycore-compat.yml`: runs an import smoke test + the non-hardware test subset against both the pinned and the latest PyPI `benchlab-pycore`, on push/PR and weekly, so a future pycore release surfaces breakage automatically instead of silently (this is exactly the class of bug this PR fixes).

Closes #6, #7, #8, #9

## Test plan

- [x] `import benchlab.core, benchlab.core.discovery, benchlab.core.datasource, benchlab.core.shared_serial, benchlab.config.config_client, benchlab.restapi.telemetry_api, benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export` succeeds with `benchlab-pycore==0.5.1` installed
- [x] `pytest tests/test_data_sources.py benchlab/restapi/test_server.py -q -k "not mqtt"` — passed locally against real hardware (17 passed, 2 deselected for missing MQTT broker)
- [x] CI workflow runs green on this PR (both `pinned` and `latest` pycore jobs passed)
- [ ] Manual review of the named-pipe/service-side protocol is still open (not covered by this PR — service isn't PyPI-distributable yet, tracked separately if needed)