### PR TITLE
Fix csv_log column-mismatch crash risk and serial import coupling

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -36,7 +36,7 @@ jobs:
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export"
 
       - name: Run non-hardware tests
-        run: pytest tests/test_data_sources.py benchlab/restapi/test_server.py -q -k "not mqtt"
+        run: pytest tests/test_data_sources.py tests/test_csv_log.py benchlab/restapi/test_server.py -q -k "not mqtt"
 
   latest:
     name: Import + test against latest pycore (PyPI)
@@ -63,4 +63,4 @@ jobs:
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export"
 
       - name: Run non-hardware tests
-        run: pytest tests/test_data_sources.py benchlab/restapi/test_server.py -q -k "not mqtt"
+        run: pytest tests/test_data_sources.py tests/test_csv_log.py benchlab/restapi/test_server.py -q -k "not mqtt"

--- a/benchlab/csv_log/csv_logger_enhanced.py
+++ b/benchlab/csv_log/csv_logger_enhanced.py
@@ -261,10 +261,11 @@ class EnhancedCSVLogger:
         try:
             while not self._stop_event.is_set():
                 # Sleep in small chunks so Ctrl+C is responsive on Windows
-                for _ in range(int(self.config.interval / 0.1)):
+                deadline = time.monotonic() + self.config.interval
+                while time.monotonic() < deadline:
                     if self._stop_event.is_set():
                         break
-                    time.sleep(0.1)
+                    time.sleep(min(0.1, deadline - time.monotonic()))
 
                 if self._stop_event.is_set():
                     break

--- a/benchlab/csv_log/message_batcher.py
+++ b/benchlab/csv_log/message_batcher.py
@@ -146,6 +146,12 @@ class CSVBatchWriter:
         self.file_locks: Dict[str, threading.Lock] = {}
         self.buffers: Dict[str, List[Dict[str, Any]]] = {}
         self.buffer_locks: Dict[str, threading.Lock] = {}
+        # Fieldnames fixed at file creation (from the first message's keys).
+        # Later messages with different keys are still written safely: extra
+        # keys are dropped, missing keys are left blank — this prevents a
+        # transient schema change (e.g. a sensor briefly absent) from
+        # crash-looping the writer or corrupting the CSV.
+        self.fieldnames: Dict[str, List[str]] = {}
 
     def write_batch(self, messages: List[Dict[str, Any]]):
         """Write a batch of messages, grouped by device UID."""
@@ -184,6 +190,7 @@ class CSVBatchWriter:
         # exists on disk and is non-empty even before the first flush.
         if messages and self.format == "csv":
             headers = list(messages[0].keys())
+            self.fieldnames[uid] = headers
             with open(filepath, "w", newline="", encoding="utf-8") as f:
                 csv.DictWriter(f, fieldnames=headers).writeheader()
             self.active_files[uid]["headers_written"] = True
@@ -201,7 +208,7 @@ class CSVBatchWriter:
         with self.file_locks[uid]:
             try:
                 if self.format == "csv":
-                    self._write_csv_batch(file_info, messages_to_write)
+                    self._write_csv_batch(uid, file_info, messages_to_write)
                 elif self.format == "json":
                     self._write_json_batch(file_info, messages_to_write)
                 self.logger.debug(f"Wrote {len(messages_to_write)} rows for {uid}")
@@ -209,11 +216,14 @@ class CSVBatchWriter:
                 self.logger.error(f"Failed to write batch for {uid}: {e}")
                 buf.extend(messages_to_write)  # restore on failure
 
-    def _write_csv_batch(self, file_info: Dict, messages: List[Dict[str, Any]]):
+    def _write_csv_batch(self, uid: str, file_info: Dict, messages: List[Dict[str, Any]]):
         filepath = file_info["filepath"]
-        headers = list(messages[0].keys())
+        headers = self.fieldnames.get(uid) or list(messages[0].keys())
         with open(filepath, "a", newline="", encoding="utf-8") as f:
-            writer = csv.DictWriter(f, fieldnames=headers)
+            # extrasaction="ignore": drop keys not in the file's header (e.g. a
+            # sensor that reappeared with a new field) instead of raising.
+            # restval="": leave missing keys blank instead of raising.
+            writer = csv.DictWriter(f, fieldnames=headers, extrasaction="ignore", restval="")
             if not file_info["headers_written"]:
                 writer.writeheader()
                 file_info["headers_written"] = True

--- a/benchlab/csv_log/smart_retry.py
+++ b/benchlab/csv_log/smart_retry.py
@@ -6,12 +6,18 @@ Provides intelligent retry strategies with exponential backoff, jitter, and circ
 import time
 import random
 import logging
-import serial
 import threading
 from typing import Callable, Any, Optional, Dict, List, Union
 from enum import Enum
 from dataclasses import dataclass
 from functools import wraps
+
+try:
+    import serial
+    _SERIAL_EXCEPTIONS: List[type] = [OSError, serial.SerialException, TimeoutError]
+except ImportError:
+    serial = None
+    _SERIAL_EXCEPTIONS = [OSError, TimeoutError]
 
 
 class RetryStrategy(Enum):
@@ -333,7 +339,7 @@ SERIAL_RETRY_CONFIG = RetryConfig(
     max_delay=10.0,
     strategy=RetryStrategy.JITTERED_EXPONENTIAL,
     jitter_factor=0.2,
-    retryable_exceptions=[OSError, serial.SerialException, TimeoutError]
+    retryable_exceptions=_SERIAL_EXCEPTIONS,
 )
 
 NETWORK_RETRY_CONFIG = RetryConfig(

--- a/tests/test_csv_log.py
+++ b/tests/test_csv_log.py
@@ -1,0 +1,129 @@
+"""Unit tests for benchlab.csv_log — no hardware required.
+
+Covers the column-mismatch bug (issue #11): a device's telemetry keys can
+vary between polls, and the CSV writer must tolerate that instead of
+crash-looping or corrupting output.
+"""
+
+import csv
+import time
+
+import pytest
+
+from benchlab.csv_log.message_batcher import (
+    BatchConfig,
+    CSVBatchWriter,
+    MessageBatcher,
+)
+from benchlab.csv_log.smart_retry import (
+    RetryConfig,
+    SmartRetryManager,
+    SERIAL_RETRY_CONFIG,
+)
+
+
+# ---------------------------------------------------------------------------
+# CSVBatchWriter: varying keys across messages
+# ---------------------------------------------------------------------------
+
+def test_writer_handles_extra_key_in_later_message(tmp_path):
+    """A later message with an extra key must not raise or wedge the writer."""
+    writer = CSVBatchWriter(str(tmp_path), batch_size=10)
+
+    writer.write_batch([{"Timestamp": "t1", "uid": "dev1", "SYS_Power": 10}])
+    # Second message carries a key not present in the header.
+    writer.write_batch([{"Timestamp": "t2", "uid": "dev1", "SYS_Power": 11, "GPU_Power": 5}])
+    writer.flush_all()
+
+    files = list(tmp_path.glob("*.csv"))
+    assert len(files) == 1
+    with open(files[0], newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows[0]["SYS_Power"] == "10"
+    assert rows[1]["SYS_Power"] == "11"
+    assert "GPU_Power" not in rows[1]  # dropped, not a crash
+
+
+def test_writer_handles_missing_key_in_later_message(tmp_path):
+    """A later message missing a header key must leave that column blank."""
+    writer = CSVBatchWriter(str(tmp_path), batch_size=10)
+
+    writer.write_batch([{"Timestamp": "t1", "uid": "dev1", "SYS_Power": 10, "GPU_Power": 5}])
+    writer.write_batch([{"Timestamp": "t2", "uid": "dev1", "SYS_Power": 11}])
+    writer.flush_all()
+
+    files = list(tmp_path.glob("*.csv"))
+    with open(files[0], newline="", encoding="utf-8") as f:
+        rows = list(csv.DictReader(f))
+    assert rows[1]["SYS_Power"] == "11"
+    assert rows[1]["GPU_Power"] == ""
+
+
+def test_writer_does_not_wedge_buffer_on_schema_drift(tmp_path):
+    """Regression: extra/missing keys used to raise inside _flush_device_buffer
+    and push the batch back into the buffer forever."""
+    writer = CSVBatchWriter(str(tmp_path), batch_size=1)
+
+    writer.write_batch([{"Timestamp": "t1", "uid": "dev1", "A": 1}])
+    writer.write_batch([{"Timestamp": "t2", "uid": "dev1", "A": 2, "B": 3}])
+
+    stats = writer.get_stats()
+    assert stats["total_buffered"] == 0  # nothing stuck after a schema change
+
+
+# ---------------------------------------------------------------------------
+# MessageBatcher: basic buffering/flush behavior
+# ---------------------------------------------------------------------------
+
+def test_batcher_flushes_at_batch_size():
+    flushed = []
+    batcher = MessageBatcher(BatchConfig(batch_size=3, flush_interval=999))
+    batcher.set_flush_callback(flushed.append)
+    try:
+        for i in range(3):
+            batcher.add_message({"i": i})
+        time.sleep(0.05)
+        assert flushed and len(flushed[0]) == 3
+    finally:
+        batcher.shutdown()
+
+
+def test_batcher_drops_messages_when_buffer_full():
+    batcher = MessageBatcher(BatchConfig(batch_size=1000, max_buffer_size=2, flush_interval=999))
+    try:
+        assert batcher.add_message({"i": 0}) is True
+        assert batcher.add_message({"i": 1}) is True
+        assert batcher.add_message({"i": 2}) is False  # buffer full, dropped
+    finally:
+        batcher.shutdown()
+
+
+# ---------------------------------------------------------------------------
+# smart_retry: importable and functional without pyserial assumptions
+# ---------------------------------------------------------------------------
+
+def test_serial_retry_config_has_retryable_exceptions():
+    assert OSError in SERIAL_RETRY_CONFIG.retryable_exceptions
+
+
+def test_retry_manager_retries_then_succeeds():
+    attempts = {"n": 0}
+
+    def flaky():
+        attempts["n"] += 1
+        if attempts["n"] < 2:
+            raise OSError("transient")
+        return "ok"
+
+    manager = SmartRetryManager(RetryConfig(max_retries=3, base_delay=0.01, circuit_breaker_enabled=False))
+    assert manager.execute(flaky) == "ok"
+    assert attempts["n"] == 2
+
+
+def test_retry_manager_raises_after_max_retries():
+    def always_fails():
+        raise OSError("nope")
+
+    manager = SmartRetryManager(RetryConfig(max_retries=2, base_delay=0.01, circuit_breaker_enabled=False))
+    with pytest.raises(OSError):
+        manager.execute(always_fails)


### PR DESCRIPTION
## Summary

- `CSVBatchWriter` derived its CSV header from only the first message it saw per device, and rebuilt `fieldnames` from the first message of each batch. If a device's telemetry keys vary between polls (e.g. a sensor briefly missing), `csv.DictWriter` would raise, the batch would be pushed back into the buffer, and the device would silently stop logging new data while repeating an ERROR log forever.
- Fix: pin the header at file creation and write with `extrasaction="ignore"` / `restval=""` so schema drift degrades gracefully (extra keys dropped, missing keys blank) instead of wedging the logger.
- `smart_retry.py` imported `serial` unconditionally just to build `SERIAL_RETRY_CONFIG`, so importing `csv_logger_enhanced` (and using the `fastapi`/`mqtt` source modes, which never touch a serial port) failed hard without `pyserial` installed. Now falls back gracefully.
- Minor: the polling sleep loop used `int(interval / 0.1)` which could round down for intervals that aren't clean multiples of 0.1s; switched to a monotonic deadline.
- Added `tests/test_csv_log.py` covering the varying-keys behavior and retry logic, wired into both `pinned` and `latest` jobs in `.github/workflows/pycore-compat.yml`.

Closes #11

## Test plan

- [x] `pytest tests/test_csv_log.py -q` — 8 passed
- [x] `pytest tests/test_data_sources.py tests/test_csv_log.py -q -k "not mqtt"` — 21 passed
- [x] Ran `csv_logger_enhanced.py --silent --auto-select` live against a connected BENCHLAB device — rows written correctly, no crashes