### PR TITLE
Fix restapi bug sweep: 404s, history limit, races, stale devices, CORS

### DIFF
--- a/benchlab/restapi/telemetry_api.py
+++ b/benchlab/restapi/telemetry_api.py
@@ -15,7 +15,6 @@ from fastapi.responses import FileResponse, JSONResponse
 from pathlib import Path
 
 from benchlab_pycore.core import read_sensors, read_device, read_uid, translate_sensor_struct
-from benchlab_pycore.core.serial_io import get_fleet_info
 from benchlab.core import BENCHLAB_ORIGINAL_PRODUCT_ID, BENCHLAB_BL2_PRODUCT_ID
 # benchlab_pycore.core.serial_io has no connection-opening helper; use the
 # local wrapper instead (see benchlab.core.shared_serial).
@@ -122,13 +121,16 @@ def device_scanner_loop():
                         start_device_thread(port, uid)
                         existing_uids.add(uid)  # Prevent duplicate starts
                 
-                # Check for disconnected devices - mark them as such
+                # Check for disconnected devices - mark them as such immediately
+                # rather than waiting for read_device_loop to notice on its own timer
                 for uid, data in devices_data.items():
                     port = data.get("port")
                     if port and port not in current_ports:
                         logger.info("Device %s appears disconnected (port %s not found)", uid, port)
-                        # The read_device_loop will detect this and mark as disconnected
-                        
+                        with data_lock:
+                            if uid in devices_data:
+                                devices_data[uid]["connected"] = False
+
                 logger.debug("Scanner: scan complete")
                         
         except Exception as e:
@@ -141,7 +143,7 @@ def device_scanner_loop():
 async def lifespan(app: FastAPI):
     # Startup
     global main_loop
-    main_loop = asyncio.get_event_loop()
+    main_loop = asyncio.get_running_loop()
     logger.info("Scanning for Benchlab devices...")
 
     found = find_benchlab_devices()
@@ -173,7 +175,8 @@ async def lifespan(app: FastAPI):
                     "history": deque(maxlen=history_length),
                     "info": device_info
                 }
-                clients[uid] = set()
+                if uid not in clients:
+                    clients[uid] = set()
 
             t = threading.Thread(target=read_device_loop, args=(port, uid), daemon=True)
             t.start()
@@ -217,10 +220,13 @@ app = FastAPI(title="Benchlab Multi-Device Telemetry API", lifespan=lifespan)
 # Qual-2.3 fix: CORS configurable via environment variable
 # Default to "*" for local dev, but can restrict to known origins in production
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*").split(",") if os.getenv("CORS_ORIGINS") else ["*"]
+# Wildcard origin + credentials is an invalid combination per the CORS spec
+# (browsers reject it) - only allow credentials when explicit origins are configured.
+CORS_ALLOW_CREDENTIALS = CORS_ORIGINS != ["*"]
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ORIGINS,
-    allow_credentials=True,
+    allow_credentials=CORS_ALLOW_CREDENTIALS,
     allow_methods=["*"],
     allow_headers=["*"],
 )
@@ -228,17 +234,20 @@ app.add_middleware(
 # --- WebSocket broadcasting ---
 async def send_updates(uid, data):
     """Push latest telemetry for this UID to all connected clients."""
-    if uid not in clients:
-        return
+    with data_lock:
+        if uid not in clients:
+            return
+        ws_list = list(clients[uid])
     dead_clients = set()
-    # Iterate over a copy to avoid RuntimeError: Set changed size during iteration
-    for ws in list(clients[uid]):
+    for ws in ws_list:
         try:
             await ws.send_json(data)
         except Exception:
             dead_clients.add(ws)
-    for ws in dead_clients:
-        clients[uid].discard(ws)
+    if dead_clients:
+        with data_lock:
+            for ws in dead_clients:
+                clients[uid].discard(ws)
 
 def schedule_update(uid, data):
     """Thread-safe schedule to send telemetry to WebSocket clients."""
@@ -497,30 +506,30 @@ def get_device_info(uid: str):
 @app.get("/device/{uid}/telemetry")
 def get_telemetry(uid: str):
     if uid not in devices_data:
-        return {"error": f"Device {uid} not found"}
+        raise HTTPException(status_code=404, detail=f"Device {uid} not found")
     return devices_data[uid].get("latest", {"status": "no data yet"})
 
 @app.get("/device/{uid}/telemetry/{sensor}")
 def get_sensor(uid: str, sensor: str):
     if uid not in devices_data:
-        return {"error": f"Device {uid} not found"}
+        raise HTTPException(status_code=404, detail=f"Device {uid} not found")
     telemetry = devices_data[uid].get("latest")
     if not telemetry:
         return {"error": "No telemetry available yet"}
     if sensor not in telemetry:
-        return {"error": f"Sensor {sensor} not found"}
+        raise HTTPException(status_code=404, detail=f"Sensor {sensor} not found")
     return {sensor: telemetry[sensor]}
 
 @app.get("/device/{uid}/history")
 def get_history(uid: str, limit: int = 100):
     """Get telemetry history with optional limit for performance."""
     if uid not in devices_data:
-        return {"error": f"Device {uid} not found"}
+        raise HTTPException(status_code=404, detail=f"Device {uid} not found")
 
+    limit = max(1, min(limit, Config.MAX_HISTORY_LIMIT))
     history = list(devices_data[uid]["history"])
     # Return only the requested limit (most recent first)
-    if limit > 0:
-        history = history[-limit:]
+    history = history[-limit:]
 
     return {
         "device_id": uid,
@@ -532,25 +541,29 @@ def get_history(uid: str, limit: int = 100):
 @app.get("/device/{uid}/sensors")
 def get_sensors(uid: str):
     if uid not in devices_data:
-        return {"error": f"Device {uid} not found"}
+        raise HTTPException(status_code=404, detail=f"Device {uid} not found")
     telemetry = devices_data[uid].get("latest", {})
     return list(telemetry.keys())
 
 @app.websocket("/device/{uid}/stream")
 async def stream_device(uid: str, ws: WebSocket):
     await ws.accept()
-    if uid not in clients:
-        clients[uid] = set()
-    clients[uid].add(ws)
-    logger.info("[%s] Client connected (%d total)", uid, len(clients[uid]))
+    with data_lock:
+        if uid not in clients:
+            clients[uid] = set()
+        clients[uid].add(ws)
+        client_count = len(clients[uid])
+    logger.info("[%s] Client connected (%d total)", uid, client_count)
     try:
         while True:
             await asyncio.sleep(1)
     except WebSocketDisconnect:
         pass
     finally:
-        clients[uid].discard(ws)  # FIX #6: use discard instead of remove to avoid KeyError
-        logger.info("[%s] Client disconnected (%d total)", uid, len(clients[uid]))
+        with data_lock:
+            clients[uid].discard(ws)  # FIX #6: use discard instead of remove to avoid KeyError
+            client_count = len(clients[uid])
+        logger.info("[%s] Client disconnected (%d total)", uid, client_count)
 
 @app.get("/favicon.ico")
 def favicon():
@@ -611,15 +624,16 @@ def get_device_status(uid: str):
 def start_device_thread(port, uid):
     """Start a telemetry reader thread for a new device."""
     # Initialize device data structure
-    if uid not in devices_data:
-        devices_data[uid] = {
-            "port": port,
-            "latest": {},
-            "history": deque(maxlen=history_length),
-            "info": {}
-        }
-    if uid not in clients:
-        clients[uid] = set()
+    with data_lock:
+        if uid not in devices_data:
+            devices_data[uid] = {
+                "port": port,
+                "latest": {},
+                "history": deque(maxlen=history_length),
+                "info": {}
+            }
+        if uid not in clients:
+            clients[uid] = set()
 
     # Try to read device info
     try:
@@ -676,6 +690,9 @@ def scan_for_devices():
             if port and port not in current_ports:
                 disconnected.append({"uid": uid, "port": port})
                 logger.info("Device %s appears to be disconnected from %s", uid, port)
+                with data_lock:
+                    if uid in devices_data:
+                        devices_data[uid]["connected"] = False
 
         result = {
             "scan_time": datetime.now().isoformat(),

--- a/benchlab/restapi/telemetry_api.py
+++ b/benchlab/restapi/telemetry_api.py
@@ -14,7 +14,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse
 from pathlib import Path
 
-from benchlab_pycore.core import read_sensors, read_device, read_uid, translate_sensor_struct
+from benchlab_pycore.core import read_sensors, read_device, translate_sensor_struct
 from benchlab.core import BENCHLAB_ORIGINAL_PRODUCT_ID, BENCHLAB_BL2_PRODUCT_ID
 # benchlab_pycore.core.serial_io has no connection-opening helper; use the
 # local wrapper instead (see benchlab.core.shared_serial).
@@ -54,7 +54,7 @@ class Config:
         if cls.SCAN_INTERVAL < 1:
             raise ValueError("SCAN_INTERVAL must be at least 1 second")
 
-# --- Logger setup --- (FIX #1: moved above Config.validate() so logger exists if validation fails)
+# --- Logger setup ---
 logger = logging.getLogger("benchlab.restapi")
 logger.setLevel(getattr(logging, Config.LOG_LEVEL.upper(), logging.INFO))
 if not logger.handlers:
@@ -82,8 +82,6 @@ devices_data = {}      # { uid: { "port": str, "latest": dict, "history": deque,
 clients = {}           # { uid: set([WebSocket, ...]) }
 main_loop = None       # Will store main asyncio loop
 shutdown_event = threading.Event()  # Graceful shutdown flag
-device_connections = {}  # { uid: serial.Serial } - Track active connections
-connection_locks = {}    # { uid: threading.Lock } - Prevent duplicate connections
 device_threads = {}    # { uid: threading.Thread } - Track device reader threads
 scan_lock = threading.Lock()  # Prevent concurrent scans
 data_lock = threading.Lock()  # Protect concurrent access to devices_data
@@ -138,7 +136,7 @@ def device_scanner_loop():
     
     logger.info("Device scanner stopped")
 
-# --- Lifespan (FIX #7: replaces deprecated @app.on_event) ---
+# --- Lifespan ---
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup
@@ -180,7 +178,7 @@ async def lifespan(app: FastAPI):
 
             t = threading.Thread(target=read_device_loop, args=(port, uid), daemon=True)
             t.start()
-            device_threads[uid] = t  # FIX #5: store thread so start_device_thread won't duplicate it
+            device_threads[uid] = t  # store thread so start_device_thread won't duplicate it
 
             # Register device in the DeviceRegistry so tools can discover it
             registry = DeviceRegistry.get_instance()
@@ -216,8 +214,7 @@ async def lifespan(app: FastAPI):
 # --- FastAPI app ---
 app = FastAPI(title="Benchlab Multi-Device Telemetry API", lifespan=lifespan)
 
-# FIX #2: CORSMiddleware is now imported (from fastapi.middleware.cors above)
-# Qual-2.3 fix: CORS configurable via environment variable
+# CORS origins configurable via environment variable.
 # Default to "*" for local dev, but can restrict to known origins in production
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*").split(",") if os.getenv("CORS_ORIGINS") else ["*"]
 # Wildcard origin + credentials is an invalid combination per the CORS spec
@@ -443,26 +440,6 @@ def find_benchlab_devices():
     """
     return _discover_devices()
 
-def read_device_info_from_port(port):
-    """Read device info from a specific port with error handling."""
-    uid, fw = "?", "?"
-    try:
-        ser = open_serial_connection(port)
-        if ser:
-            info = read_device(ser) or {}
-            fw = info.get("FwVersion", "?")
-            uid_read = read_uid(ser)
-            if uid_read:
-                uid = uid_read
-            ser.close()
-            logger.info("Found device on %s: UID=%s, FW=%s", port, uid, fw)
-            return {"port": port, "uid": uid, "fw": fw}
-        else:
-            logger.warning("Could not open serial port %s", port)
-    except Exception as e:
-        logger.debug("Failed to read device on %s: %s", port, e)
-    return None
-
 # --- API endpoints ---
 @app.get("/devices")
 def list_devices():
@@ -561,7 +538,7 @@ async def stream_device(uid: str, ws: WebSocket):
         pass
     finally:
         with data_lock:
-            clients[uid].discard(ws)  # FIX #6: use discard instead of remove to avoid KeyError
+            clients[uid].discard(ws)
             client_count = len(clients[uid])
         logger.info("[%s] Client disconnected (%d total)", uid, client_count)
 
@@ -575,7 +552,7 @@ def health_check():
     """Basic health check endpoint for monitoring."""
     return {
         "status": "healthy",
-        "platform": sys.platform,  # FIX #3: sys is now imported
+        "platform": sys.platform,
         "timestamp": datetime.now().isoformat(),
         "connected_devices": len(devices_data),
         "total_clients": sum(len(clients.get(uid, [])) for uid in devices_data)
@@ -596,7 +573,7 @@ def get_status():
 
     return {
         "server_status": "running",
-        "platform": sys.platform,  # FIX #3: sys is now imported
+        "platform": sys.platform,
         "timestamp": datetime.now().isoformat(),
         "devices": device_status,
         "total_devices": len(devices_data),
@@ -607,7 +584,7 @@ def get_status():
 def get_device_status(uid: str):
     """Get detailed status for a specific device."""
     if uid not in devices_data:
-        raise HTTPException(status_code=404, detail=f"Device {uid} not found")  # FIX #4: HTTPException now imported
+        raise HTTPException(status_code=404, detail=f"Device {uid} not found")
 
     data = devices_data[uid]
     return {
@@ -660,7 +637,7 @@ def scan_for_devices():
     """Scan for new BenchLab devices and start telemetry for newly discovered ones.
 
     This endpoint allows runtime device discovery without restarting the server.
-    Only devices with BenchLab hardware ID (VID:PID=0483:5740) will be opened.
+    Only devices matching a known BenchLab product ID (ORIGINAL or BL2) will be opened.
     """
     with scan_lock:
         logger.info("Manual device scan triggered...")
@@ -712,7 +689,7 @@ def scan_for_devices():
 async def global_exception_handler(request, exc):
     """Global exception handler for unhandled errors."""
     logger.error(f"Unhandled exception: {exc}")
-    return JSONResponse(  # FIX #4: JSONResponse now imported
+    return JSONResponse(
         status_code=500,
         content={"error": "Internal server error", "message": str(exc)}
     )

--- a/benchlab/restapi/test_server.py
+++ b/benchlab/restapi/test_server.py
@@ -75,30 +75,22 @@ def test_api_endpoints():
         print(f"✗ API endpoint test failed: {e}")
         return False
 
-def test_cross_platform_detection():
-    """Test cross-platform device detection logic."""
-    print("\nTesting cross-platform device detection...")
-    
+def test_device_discovery():
+    """Test that device discovery is callable and returns a list."""
+    print("\nTesting device discovery...")
+
     try:
-        import sys
-        from benchlab.restapi.telemetry_api import get_device_ports
-        
-        # Test platform detection
-        ports = get_device_ports()
-        
-        if sys.platform.startswith('win'):
-            expected_ports = ['COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9']
-            assert ports == expected_ports
-            print("✓ Windows port detection working")
-        else:
-            # Linux/Unix - should return glob patterns
-            assert len(ports) > 0
-            print("✓ Unix port detection working")
-            
+        from benchlab.restapi.telemetry_api import find_benchlab_devices
+
+        # No hardware required - just verify it runs and returns a list
+        devices = find_benchlab_devices()
+        assert isinstance(devices, list)
+        print("✓ Device discovery working")
+
         return True
-        
+
     except Exception as e:
-        print(f"✗ Cross-platform detection test failed: {e}")
+        print(f"✗ Device discovery test failed: {e}")
         return False
 
 def test_error_handling():
@@ -173,7 +165,7 @@ def main():
     tests = [
         test_server_startup,
         test_api_endpoints,
-        test_cross_platform_detection,
+        test_device_discovery,
         test_error_handling
     ]
     


### PR DESCRIPTION
Closes #16

## Summary
Bug sweep of `benchlab/restapi` (telemetry_api.py, test_server.py), continuing the repo-wide sweep after csv_log and tui.

- `get_telemetry`/`get_sensor`/`get_history`/`get_sensors` now raise `HTTPException(404)` for unknown devices/sensors instead of returning `{"error": ...}` with HTTP 200
- `get_history` now clamps `limit` to `Config.MAX_HISTORY_LIMIT`, which was previously defined and validated but never enforced
- `device_scanner_loop` and `scan_for_devices` mark devices as disconnected immediately instead of waiting for `read_device_loop`'s own timer
- `lifespan` uses `asyncio.get_running_loop()` instead of the deprecated `get_event_loop()`
- `clients` dict mutations are now guarded by `data_lock`, matching `devices_data`
- CORS no longer combines `allow_origins=["*"]` with `allow_credentials=True` (invalid combination, rejected by browsers) — was also the out-of-the-box default
- `test_server.py`: replaced `test_cross_platform_detection`, which imported a `get_device_ports` function that doesn't exist in `telemetry_api.py` and always failed, with a test of the actual `find_benchlab_devices()` discovery path

Plus a cleanup pass: removed unused globals (`device_connections`, `connection_locks`), an unused function (`read_device_info_from_port`) and its now-unused `read_uid` import, stale `FIX #N` comments from a past refactor, and corrected a stale `/scan` docstring that claimed a hardcoded VID:PID filter (discovery actually filters by BenchLab product ID via `discover_devices()`).

## Test plan
- [x] `pytest benchlab/restapi/test_server.py` — 4/4 passing
- [x] Started server locally against a real connected BenchLab device; confirmed 404s on `/device/{fake}/telemetry`, `/history`, `/sensors`, `/status`
- [x] Confirmed `limit=0` and `limit=99999` on `/device/{uid}/history` clamp correctly against live device data
- [x] CI (`pycore-compat.yml`) already exercises `benchlab.restapi.telemetry_api` import + `test_server.py` against both pinned and latest pycore