### PR TITLE
Fix hwinfo bug sweep: stale devices, timestamp leak, dead retry, dead code

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Test - graph application logic
         run: pytest benchlab/graph/test_graph.py -v -k "not mqtt"
 
+      - name: Test - hwinfo export
+        run: pytest benchlab/hwinfo/test_hwinfo_export.py -v -k "not mqtt"
+
   latest:
     name: Import + test against latest pycore (PyPI)
     runs-on: windows-latest
@@ -100,3 +103,6 @@ jobs:
 
       - name: Test - graph application logic
         run: pytest benchlab/graph/test_graph.py -v -k "not mqtt"
+
+      - name: Test - hwinfo export
+        run: pytest benchlab/hwinfo/test_hwinfo_export.py -v -k "not mqtt"

--- a/benchlab/hwinfo/README.md
+++ b/benchlab/hwinfo/README.md
@@ -72,7 +72,7 @@ During runtime or on exit:
 
 Run the exporter from the BenchLab project directory:
 
-python -m benchlab.hwinfo_export
+python benchlab.py -hwinfo
 
 
 It will:

--- a/benchlab/hwinfo/hwinfo_export.py
+++ b/benchlab/hwinfo/hwinfo_export.py
@@ -50,8 +50,6 @@ def get_sensor_type_and_unit(key):
         return "Clock", None
     elif "duty" in key_lower:
         return "Other", "%"
-    elif "fanextduty" in key_lower:
-        return "Other", "%"
     else:
         return "Other", "%"
 
@@ -100,7 +98,7 @@ def _process_sensor_data(data: dict) -> dict:
     }
 
     for key, value in data.items():
-        if key in IGNORE_KEYS or key.lower() == "fanextduty":
+        if key in IGNORE_KEYS or key.lower() in ("fanextduty", "timestamp"):
             continue
 
         sensor_type, unit = get_sensor_type_and_unit(key)
@@ -157,9 +155,7 @@ def export_device_sensors(device_info, datasource=None):
         # Use provided data source
         data = datasource.get_telemetry(uid)
         if not data:
-            # Try to refresh (DirectDataSource polls, FastAPI/MQTT get latest)
-            logger.debug("No telemetry for %s via %s, retrying...", uid, datasource.source_type)
-            data = datasource.get_telemetry(uid)
+            logger.debug("No telemetry for %s via %s yet", uid, datasource.source_type)
     else:
         # Fallback: direct probe via pycore (legacy behavior)
         try:
@@ -289,6 +285,16 @@ def export_all_devices(update_interval=1, datasource=None):
         while True:
             # Get device list from data source
             fleet = datasource.list_devices()
+
+            # Remove registry entries for devices no longer present in the fleet
+            current_device_names = {
+                f"BENCHLAB_{device.get('port', 'unknown')}_{device.get('uid', 'unknown')}"
+                for device in fleet
+            }
+            for stale_name in exported_devices - current_device_names:
+                delete_registry_tree(HWINFO_CUSTOM_ROOT, f"{HWINFO_CUSTOM_PATH}\\{stale_name}")
+                exported_devices.discard(stale_name)
+
             if not fleet:
                 logger.warning("No BenchLab devices found via %s", datasource.source_type)
                 time.sleep(update_interval)

--- a/benchlab/hwinfo/test_hwinfo_export.py
+++ b/benchlab/hwinfo/test_hwinfo_export.py
@@ -1,0 +1,99 @@
+"""Non-hardware regression tests for benchlab.hwinfo.hwinfo_export.
+
+These tests exercise the sensor grouping/filtering logic and the
+export_all_devices stale-device cleanup with a fake datasource and a mocked
+winreg — no physical BenchLab device or Windows registry access is required.
+They guard against the bugs fixed in the hwinfo bug sweep (issue #20):
+timestamp leaking into the exported sensors, stale registry entries for
+disconnected devices, and the dead sensor-type branch.
+"""
+
+import sys
+import types
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("win"), reason="hwinfo export is Windows-only"
+)
+
+from benchlab.hwinfo import hwinfo_export as hw
+
+
+def test_get_sensor_type_and_unit_fanextduty_still_other_percent():
+    """FanExtDuty is matched by the 'duty' branch; removing the redundant
+    'fanextduty' elif must not change its classification."""
+    assert hw.get_sensor_type_and_unit("FanExtDuty") == ("Other", "%")
+
+
+def test_process_sensor_data_skips_timestamp():
+    data = {"Chip_Temp": 42.123, "timestamp": "2026-08-15T10:00:00+00:00"}
+    grouped = hw._process_sensor_data(data)
+
+    all_keys = [key for group in grouped.values() for key, _, _ in group]
+    assert "timestamp" not in all_keys
+    assert "Chip_Temp" in all_keys
+
+
+def test_process_sensor_data_skips_fanextduty_and_fan_status():
+    data = {
+        "FanExtDuty": 50.0,
+        "Fan1_Status": 1,
+        "Fan1_RPM": 1200.0,
+    }
+    grouped = hw._process_sensor_data(data)
+
+    all_keys = [key for group in grouped.values() for key, _, _ in group]
+    assert "FanExtDuty" not in all_keys
+    assert "Fan1_Status" not in all_keys
+    assert "Fan1_RPM" in all_keys
+
+
+class FakeDataSource:
+    def __init__(self, fleets):
+        self._fleets = list(fleets)
+        self.source_type = "direct"
+
+    def list_devices(self):
+        return self._fleets.pop(0) if self._fleets else []
+
+    def get_telemetry(self, uid):
+        return {"Chip_Temp": 42.0}
+
+    def disconnect(self):
+        pass
+
+
+def test_export_all_devices_removes_stale_registry_entry(monkeypatch):
+    """Regression test for issue #20: a device present in one cycle and gone
+    the next must have its registry subkey removed, not left stale."""
+    hw.exported_devices.clear()
+
+    deleted_paths = []
+    monkeypatch.setattr(hw, "delete_registry_tree", lambda root, path: deleted_paths.append(path))
+    monkeypatch.setattr(hw, "write_hwinfo_sensor", lambda *a, **kw: None)
+    monkeypatch.setattr(hw.winreg, "OpenKey", lambda *a, **kw: (_ for _ in ()).throw(FileNotFoundError()))
+
+    device = {"uid": "UID-1", "port": "COM3"}
+    device_name = "BENCHLAB_COM3_UID-1"
+
+    # Cycle 1: device present. Cycle 2: fleet empty (device unplugged).
+    # KeyboardInterrupt on the third list_devices() call ends the loop.
+    call_count = {"n": 0}
+    fleets = [[device], []]
+
+    def list_devices_side_effect():
+        call_count["n"] += 1
+        if call_count["n"] > len(fleets):
+            raise KeyboardInterrupt
+        return fleets[call_count["n"] - 1]
+
+    ds = FakeDataSource([])
+    ds.list_devices = list_devices_side_effect
+
+    monkeypatch.setattr(hw.time, "sleep", lambda s: None)
+
+    hw.export_all_devices(update_interval=0, datasource=ds)
+
+    assert f"{hw.HWINFO_CUSTOM_PATH}\\{device_name}" in deleted_paths
+    assert device_name not in hw.exported_devices


### PR DESCRIPTION
Closes #20

## Summary
Bug sweep of `benchlab/hwinfo/hwinfo_export.py`, continuing the repo-wide sweep after csv_log, tui, restapi, and graph.

- `export_all_devices` now diffs the current fleet against `exported_devices` each polling cycle and removes registry subkeys for devices no longer present, instead of only purging stale `BENCHLAB_*` keys once at startup and again at final Ctrl+C cleanup. Previously a device unplugged mid-run kept showing frozen, stale sensor values in HWiNFO indefinitely.
- `_process_sensor_data` now also skips the `timestamp` key that `DirectDataSource` stamps onto every telemetry dict, instead of exporting it as a bogus `"Other"`-type sensor containing an ISO datetime string.
- Removed the no-op immediate retry in `export_device_sensors`: calling `datasource.get_telemetry(uid)` twice back-to-back with no delay can't give a background polling thread time to populate new data, so it always returned the same falsy result.
- Removed the unreachable `"fanextduty"` `elif` branch in `get_sensor_type_and_unit` — it's already caught by the `"duty"` branch above it and returns the same value as the final `else` anyway.
- Corrected `hwinfo/README.md`'s stale `python -m benchlab.hwinfo_export` launch instructions to the real entry point, `python benchlab.py -hwinfo`.
- Added `benchlab/hwinfo/test_hwinfo_export.py` (previously zero coverage) and wired it into `pycore-compat.yml`'s pytest steps in both jobs.

Note: HWiNFO integration is Windows-only by design (uses `winreg`), matching how CI already runs this module's checks on `windows-latest` only — no Linux compatibility work was in scope.

## Test plan
- [x] `ast.parse` syntax check on modified files
- [x] New pytest suite (`test_hwinfo_export.py`) passes locally: timestamp filtering, FanExtDuty classification unchanged after dead-branch removal, stale-device registry cleanup across polling cycles
- [x] Verified `benchlab.hwinfo.hwinfo_export` still imports cleanly
- [ ] No physical HWiNFO/registry-in-the-loop CI exists, so full interactive verification (running the exporter against real HWiNFO with a live device) was not possible; the above scripted checks mock `winreg` and exercise the same code paths headlessly