### PR TITLE
Fix wigidash bug sweep: USB leak, telemetry race, stale devices, dead debounce

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -27,6 +27,7 @@ jobs:
           pip install -r requirements.txt
           pip install -r benchlab/csv_log/requirements.txt
           pip install -r benchlab/graph/requirements.txt
+          pip install -r benchlab/wigidash/requirements.txt
           pip install pytest
 
       - name: Import smoke test
@@ -36,7 +37,11 @@ jobs:
           benchlab.config.config_client, benchlab.restapi.telemetry_api,
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export,
           benchlab.tui.config, benchlab.tui.tui_core, benchlab.tui.tui_main,
-          benchlab.graph.app, benchlab.graph.ui"
+          benchlab.graph.app, benchlab.graph.ui,
+          benchlab.wigidash.wigidash_manager, benchlab.wigidash.wigidash_usb,
+          benchlab.wigidash.wigidash_device, benchlab.wigidash.wigidash_session,
+          benchlab.wigidash.benchlab_telemetry, benchlab.wigidash.benchlab_fleet,
+          benchlab.wigidash.benchlab_overview, benchlab.wigidash.benchlab_graph"
 
       - name: Test - core data sources
         run: pytest tests/test_data_sources.py -v -k "not mqtt"
@@ -58,6 +63,9 @@ jobs:
 
       - name: Test - hwinfo export
         run: pytest benchlab/hwinfo/test_hwinfo_export.py -v -k "not mqtt"
+
+      - name: Test - wigidash
+        run: pytest benchlab/wigidash/test_wigidash.py -v -k "not mqtt"
 
   latest:
     name: Import + test against latest pycore (PyPI)
@@ -74,6 +82,7 @@ jobs:
           pip install -r requirements.txt
           pip install -r benchlab/csv_log/requirements.txt
           pip install -r benchlab/graph/requirements.txt
+          pip install -r benchlab/wigidash/requirements.txt
           pip install pytest
           pip install --upgrade benchlab-pycore
 
@@ -84,7 +93,11 @@ jobs:
           benchlab.config.config_client, benchlab.restapi.telemetry_api,
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export,
           benchlab.tui.config, benchlab.tui.tui_core, benchlab.tui.tui_main,
-          benchlab.graph.app, benchlab.graph.ui"
+          benchlab.graph.app, benchlab.graph.ui,
+          benchlab.wigidash.wigidash_manager, benchlab.wigidash.wigidash_usb,
+          benchlab.wigidash.wigidash_device, benchlab.wigidash.wigidash_session,
+          benchlab.wigidash.benchlab_telemetry, benchlab.wigidash.benchlab_fleet,
+          benchlab.wigidash.benchlab_overview, benchlab.wigidash.benchlab_graph"
 
       - name: Test - core data sources
         run: pytest tests/test_data_sources.py -v -k "not mqtt"
@@ -106,3 +119,6 @@ jobs:
 
       - name: Test - hwinfo export
         run: pytest benchlab/hwinfo/test_hwinfo_export.py -v -k "not mqtt"
+
+      - name: Test - wigidash
+        run: pytest benchlab/wigidash/test_wigidash.py -v -k "not mqtt"

--- a/benchlab/wigidash/README.md
+++ b/benchlab/wigidash/README.md
@@ -49,7 +49,12 @@ Dependencies include:
 - NumPy
 - pyserial
 - pyusb
+- libusb-package (Windows only — provides the libusb-1.0 backend pyusb needs)
 - benchlab core modules
+
+### Windows Setup
+
+`pyusb` needs a `libusb-1.0` backend DLL, which isn't bundled with the `pyusb` pip package itself. `requirements.txt` includes `libusb-package`, which provides a prebuilt backend that `pyusb` auto-discovers — plain `pip install -r requirements.txt` in any standard Python environment (venv, system Python, etc.) is enough; no Anaconda/conda-forge install is required.
 
 ### Linux Setup
 

--- a/benchlab/wigidash/README.md
+++ b/benchlab/wigidash/README.md
@@ -59,16 +59,18 @@ Dependencies include:
 wigidash/
 ├─ README.md
 ├─ assets/ # Fonts, logos, and other UI resources
-├─ init.py
+├─ __init__.py
 ├─ benchlab_fleet.py # Fleet selection UI
 ├─ benchlab_graph.py # Graph rendering and metric selection
 ├─ benchlab_overview.py # Overview page for system telemetry
 ├─ benchlab_telemetry.py # Data logging and historical telemetry handling
+├─ benchlab_ui.py # Shared UI toolkit: theme, buttons, header/footer drawing
 ├─ benchlab_utils.py # Utilities for image display, logging, and device management
 ├─ wigidash_device.py # Device abstraction layer
+├─ wigidash_manager.py # Top-level orchestrator: device discovery, session/telemetry management
+├─ wigidash_session.py # Per-device UI session and page lifecycle
 ├─ wigidash_usb.py # USB communication layer
 ├─ wigidash_widget.py # Dashboard widget configuration
-├─ wigidash_launcher.py # Launcher for the dashboard
 └─ requirements.txt
 
 
@@ -79,7 +81,7 @@ wigidash/
 ### Launch the Dashboard
 
 ```
-python wigidash_launcher.py
+python benchlab.py -wigidash
 ```
 
 Behavior:

--- a/benchlab/wigidash/README.md
+++ b/benchlab/wigidash/README.md
@@ -51,6 +51,30 @@ Dependencies include:
 - pyusb
 - benchlab core modules
 
+### Linux Setup
+
+`pyusb` needs a working `libusb-1.0` backend and permission to access the WigiDash's USB device node as a non-root user.
+
+1. Install libusb (relevant on minimal/ARM images, e.g. Raspberry Pi OS Lite, which may not ship it by default):
+
+   ```
+   sudo apt install libusb-1.0-0
+   ```
+
+2. Grant non-root USB access by creating `/etc/udev/rules.d/99-wigidash.rules`:
+
+   ```
+   SUBSYSTEM=="usb", ATTR{idVendor}=="28da", ATTR{idProduct}=="ef01", TAG+="uaccess"
+   ```
+
+   Then reload udev rules:
+
+   ```
+   sudo udevadm control --reload-rules && sudo udevadm trigger
+   ```
+
+   Without this rule, `pyusb` calls typically fail with an `Access denied (insufficient permissions)` USB error unless run as root. On startup, `scan_wigidash()` runs a best-effort check for this and logs an actionable warning (with the same rule text above) if it looks like access isn't set up — this is a diagnostic only, not a hard requirement check, since udev setups vary across distros.
+
 
 ---
 

--- a/benchlab/wigidash/benchlab_fleet.py
+++ b/benchlab/wigidash/benchlab_fleet.py
@@ -20,6 +20,7 @@ class BenchlabFleetSelect:
         self.manager = fleet_manager
         self.on_exit = on_exit
         self.last_tap_time = 0
+        self.last_touch_time = 0
         self.keepalive = KeepAliveManager(self.wigidash)
 
         # Fonts and logo from central UI
@@ -70,7 +71,7 @@ class BenchlabFleetSelect:
             return
 
         now = int(time.monotonic() * 1000)
-        if now - getattr(self, "last_touch_time", 0) < 0.1:
+        if now - self.last_touch_time < 150:
             return
 
         if touch is None or getattr(touch, "Type", 0) == 0:
@@ -81,6 +82,8 @@ class BenchlabFleetSelect:
         # Ignore touches immediately after page start
         if now - getattr(self, "start_time", now) < 500:
             return
+
+        self.last_touch_time = now
 
         # Footer buttons
         for btn in self.footer_hitboxes:

--- a/benchlab/wigidash/benchlab_graph.py
+++ b/benchlab/wigidash/benchlab_graph.py
@@ -79,7 +79,7 @@ class BenchlabGraph:
             return
 
         now = int(time.monotonic() * 1000)
-        if now - getattr(self, "last_touch_time", 0) < 0.1:
+        if now - getattr(self, "last_touch_time", 0) < 150:
             return
 
         if touch is None or getattr(touch, "Type", 0) == 0:

--- a/benchlab/wigidash/benchlab_overview.py
+++ b/benchlab/wigidash/benchlab_overview.py
@@ -54,6 +54,7 @@ class BenchlabOverview:
         self.requested_graph_metrics = None
         self.x1 = self.x2 = self.x3 = 0
         self.col1_width = self.col2_width = self.col3_width = 0
+        self.last_touch_time = 0
 
     # -------------------------------
     # Page Handling
@@ -72,11 +73,13 @@ class BenchlabOverview:
             return
 
         now = int(time.monotonic() * 1000)
-        if now - getattr(self, "last_touch_time", 0) < 0.1:
+        if now - self.last_touch_time < 150:
             return
 
         if touch is None or getattr(touch, "Type", 0) == 0:
             return
+
+        self.last_touch_time = now
 
         x, y = getattr(touch, "X", 0), getattr(touch, "Y", 0)
 
@@ -134,10 +137,6 @@ class BenchlabOverview:
             if x0 <= x <= x1 and y0 <= y <= y1:
                 logger.info(f"Card pressed, opening graph for: {metrics}")
                 self.running = False
-                try:
-                    self.stop()
-                except:
-                    pass
                 self.requested_graph_metrics = metrics
                 return
 

--- a/benchlab/wigidash/benchlab_telemetry.py
+++ b/benchlab/wigidash/benchlab_telemetry.py
@@ -77,11 +77,13 @@ def telemetry_step(app, device_info=None, sensor_struct=None):
         if not isinstance(sensor_struct, dict):
             logger.warning("Unexpected sensor_struct type: %s", type(sensor_struct))
             return
-        data = sensor_struct
+        data = dict(sensor_struct)
 
         # --- Cleanup & normalization ---
-        data.setdefault("Fans", [])
-        data.setdefault("Vin", [])
+        # Copy Fans/Vin too so the in-place mutations below don't leak back
+        # into the caller's original lists/dicts.
+        data["Fans"] = [dict(fan) for fan in data.get("Fans", [])]
+        data["Vin"] = list(data.get("Vin", []))
         for fan in data["Fans"]:
             fan.setdefault("RPM", 0)
             fan.setdefault("Duty", 0)

--- a/benchlab/wigidash/benchlab_utils.py
+++ b/benchlab/wigidash/benchlab_utils.py
@@ -113,11 +113,11 @@ class KeepAliveManager:
             self.thread = None
 
     def mark_active(self):
-	    try:
-	        if self.wigidash and hasattr(self.wigidash, "clear_screen_timeout"):
-	            self.wigidash.clear_screen_timeout()
-	    except Exception as e:
-	        logger.warning("Keepalive error: %s", e)
+        try:
+            if self.wigidash and hasattr(self.wigidash, "clear_screen_timeout"):
+                self.wigidash.clear_screen_timeout()
+        except Exception as e:
+            logger.warning("Keepalive error: %s", e)
 
     def loop(self):
         step = 0.1
@@ -161,7 +161,7 @@ def shutdown_wigidash(wigi_instance):
             logger.warning(f"Error shutting down display: {e}")
     
     # Disconnect USB
-    usb_dev = getattr(wigi_instance, "usb_dev", None)
+    usb_dev = getattr(wigi_instance, "usb_device", None)
     if usb_dev:
         try:
             logger.info("Disconnecting USB device...")

--- a/benchlab/wigidash/requirements.txt
+++ b/benchlab/wigidash/requirements.txt
@@ -4,4 +4,6 @@ numpy>=2.2.0
 pyusb>=1.3.1
 pyserial>=3.5
 
-# also need to conda install -c conda-forge libusb to work with pyusb on windows
+# Provides a prebuilt libusb-1.0 backend for pyusb on Windows (no conda
+# required) — pyusb auto-discovers it once installed.
+libusb-package>=1.0.26.1; sys_platform == "win32"

--- a/benchlab/wigidash/test_wigidash.py
+++ b/benchlab/wigidash/test_wigidash.py
@@ -1,0 +1,166 @@
+"""Non-hardware regression tests for benchlab.wigidash.
+
+These tests exercise the pure-Python logic bugs fixed in the wigidash bug
+sweep (issue #22) with fakes/mocks — no physical WigiDash USB device or
+BenchLab hardware is required:
+- WigidashManager.get_available_benchlabs pruning stale/disconnected ports
+- WigidashManager.start_telemetry's lock preventing duplicate telemetry
+  contexts/threads when called concurrently for the same port
+- telemetry_step not mutating the caller's input dict in place
+- The touch debounce threshold in benchlab_overview/benchlab_graph/benchlab_fleet
+"""
+
+import threading
+import time
+
+from benchlab.wigidash.wigidash_manager import WigidashManager
+from benchlab.wigidash.benchlab_telemetry import telemetry_step, TelemetryContext, TelemetryHistory
+
+
+class FakeDataSource:
+    def __init__(self, fleets):
+        self._fleets = list(fleets)
+        self._selected = None
+
+    def list_devices(self):
+        return self._fleets.pop(0) if self._fleets else []
+
+    def select_device(self, uid):
+        self._selected = uid
+
+    def snapshot(self):
+        return {"device_info": {}, "sensor_data": {}}
+
+
+def test_get_available_benchlabs_prunes_stale_port():
+    device = {"port": "COM3", "uid": "UID-1", "firmware": "1.0"}
+    ds = FakeDataSource([[device], []])
+    mgr = WigidashManager(datasource=ds)
+
+    mgr.get_available_benchlabs(log_info=False)
+    assert "COM3" in mgr.benchlab_devices
+
+    mgr.get_available_benchlabs(log_info=False)
+    assert "COM3" not in mgr.benchlab_devices
+
+
+def test_get_available_benchlabs_keeps_devices_on_query_failure():
+    """A transient list_devices() failure must not wipe out known devices."""
+    device = {"port": "COM3", "uid": "UID-1", "firmware": "1.0"}
+
+    class FlakyDataSource(FakeDataSource):
+        def __init__(self):
+            super().__init__([[device]])
+            self._calls = 0
+
+        def list_devices(self):
+            self._calls += 1
+            if self._calls == 1:
+                return [device]
+            raise RuntimeError("transient failure")
+
+    ds = FlakyDataSource()
+    mgr = WigidashManager(datasource=ds)
+
+    mgr.get_available_benchlabs(log_info=False)
+    assert "COM3" in mgr.benchlab_devices
+
+    mgr.get_available_benchlabs(log_info=False)
+    assert "COM3" in mgr.benchlab_devices
+
+
+class FakeSession:
+    def __init__(self):
+        self.ser = None
+        self.device_info = None
+        self.uid = None
+        self.telemetry_history = None
+        self.history = None
+        self.selected_port = None
+        self.telemetry_context = None
+
+
+def test_start_telemetry_lock_prevents_duplicate_contexts():
+    """Regression test for issue #22: two near-simultaneous start_telemetry
+    calls for the same port must not create two telemetry_contexts entries."""
+    device = {"port": "COM3", "uid": "UID-1", "firmware": "1.0"}
+    ds = FakeDataSource([[device]])
+    mgr = WigidashManager(datasource=ds)
+    mgr.get_available_benchlabs(log_info=False)
+    mgr.shutdown_event.set()  # stop telemetry_loop threads immediately after they start
+
+    barrier = threading.Barrier(2)
+
+    def call_start_telemetry(session):
+        barrier.wait(timeout=2)
+        mgr.start_telemetry("COM3", session)
+
+    sessions = [FakeSession(), FakeSession()]
+    threads = [threading.Thread(target=call_start_telemetry, args=(s,)) for s in sessions]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=2)
+
+    assert len(mgr.telemetry_contexts) == 1
+    ctx = mgr.telemetry_contexts["COM3"]
+    assert len(ctx.sessions) == 2
+
+
+def test_telemetry_step_does_not_mutate_caller_dict():
+    ctx = TelemetryContext(port="COM3", ser=None, device_info={}, uid="UID-1", history=TelemetryHistory())
+    original = {"Fans": [{"RPM": 1200}], "Vin": [None, 3.3]}
+    original_fans_list = original["Fans"]
+    original_fan_dict = original["Fans"][0]
+
+    telemetry_step(ctx, sensor_struct=original)
+
+    # Caller's dict/list/nested-dict identities must be untouched.
+    assert "Duty" not in original_fan_dict
+    assert original["Vin"] == [None, 3.3]
+    assert original["Fans"] is original_fans_list
+    assert ctx.sensor_data["Fans"][0]["Duty"] == 0
+    assert ctx.sensor_data["Vin"] == [0.0, 3.3]
+
+
+class FakeTouch:
+    def __init__(self, x, y):
+        self.Type = 1
+        self.X = x
+        self.Y = y
+
+
+def test_overview_debounce_rejects_rapid_touch_and_accepts_later_one():
+    """Regression test for issue #22: check_touch used a 0.1ms threshold and
+    never set last_touch_time, making the debounce permanently dead."""
+    from benchlab.wigidash.benchlab_overview import BenchlabOverview
+
+    overview = BenchlabOverview(wigidash=object(), wigi=object())
+    overview.running = True
+    overview.footer_btn_config = []
+
+    # Coordinates inside the bottom-left "power" card (x0=PADDING, y0=bottom_y).
+    padding = overview.PADDING
+    bottom_y = overview.HEADER_HEIGHT + padding + 160 + padding
+    hit_x, hit_y = padding + 5, bottom_y + 5
+
+    # First touch (well past any startup guard) hits the card and starts debounce.
+    overview.last_touch_time = 0
+    overview.check_touch(FakeTouch(hit_x, hit_y))
+    assert overview.requested_graph_metrics is not None
+
+    # Reset state, then simulate a second touch arriving 10ms later — within
+    # the debounce window — it must be ignored.
+    overview.running = True
+    overview.requested_graph_metrics = None
+    overview.last_touch_time = int(time.monotonic() * 1000) - 10
+    overview.check_touch(FakeTouch(hit_x, hit_y))
+    assert overview.requested_graph_metrics is None, (
+        "debounce failed to reject a touch 10ms after the previous one"
+    )
+
+    # A touch after the debounce window elapses is allowed through again.
+    overview.last_touch_time = int(time.monotonic() * 1000) - 200
+    overview.check_touch(FakeTouch(hit_x, hit_y))
+    assert overview.requested_graph_metrics is not None
+

--- a/benchlab/wigidash/test_wigidash.py
+++ b/benchlab/wigidash/test_wigidash.py
@@ -259,3 +259,42 @@ def test_is_permission_error_detects_known_signals():
     assert wigidash_usb._is_permission_error(Exception("Operation not permitted")) is True
     assert wigidash_usb._is_permission_error(Exception("Resource busy")) is False
 
+
+def test_scan_wigidash_passes_explicit_backend_when_available(monkeypatch):
+    """Regression test: on Windows, pyusb's default backend discovery can
+    silently pick up an unrelated system-wide libusb-1.0.dll instead of the
+    one bundled with libusb-package, so scan_wigidash must pass the
+    libusb-package backend explicitly rather than relying on auto-discovery."""
+    sentinel_backend = object()
+    monkeypatch.setattr(wigidash_usb, "_usb_backend", sentinel_backend)
+
+    captured_kwargs = {}
+
+    def fake_find(**kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    monkeypatch.setattr(wigidash_usb.usb.core, "find", fake_find)
+
+    wigidash_usb.scan_wigidash(0x28DA, 0xEF01)
+
+    assert captured_kwargs.get("backend") is sentinel_backend
+
+
+def test_scan_wigidash_omits_backend_kwarg_when_unavailable(monkeypatch):
+    """When libusb-package isn't installed/usable, fall back to pyusb's
+    normal backend discovery instead of passing backend=None explicitly."""
+    monkeypatch.setattr(wigidash_usb, "_usb_backend", None)
+
+    captured_kwargs = {}
+
+    def fake_find(**kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    monkeypatch.setattr(wigidash_usb.usb.core, "find", fake_find)
+
+    wigidash_usb.scan_wigidash(0x28DA, 0xEF01)
+
+    assert "backend" not in captured_kwargs
+

--- a/benchlab/wigidash/test_wigidash.py
+++ b/benchlab/wigidash/test_wigidash.py
@@ -8,13 +8,16 @@ BenchLab hardware is required:
   contexts/threads when called concurrently for the same port
 - telemetry_step not mutating the caller's input dict in place
 - The touch debounce threshold in benchlab_overview/benchlab_graph/benchlab_fleet
+- The Linux USB-permissions preflight check and udev rule detection
 """
 
+import os
 import threading
 import time
 
 from benchlab.wigidash.wigidash_manager import WigidashManager
 from benchlab.wigidash.benchlab_telemetry import telemetry_step, TelemetryContext, TelemetryHistory
+from benchlab.wigidash import wigidash_usb
 
 
 class FakeDataSource:
@@ -163,4 +166,96 @@ def test_overview_debounce_rejects_rapid_touch_and_accepts_later_one():
     overview.last_touch_time = int(time.monotonic() * 1000) - 200
     overview.check_touch(FakeTouch(hit_x, hit_y))
     assert overview.requested_graph_metrics is not None
+
+
+# ----------------------------------------------------------------------
+# Linux USB permissions preflight (issue: no plugdev/udev check on Linux)
+# ----------------------------------------------------------------------
+
+def test_udev_rule_exists_matches_vid_pid(tmp_path):
+    rules_dir = tmp_path / "rules.d"
+    rules_dir.mkdir()
+    (rules_dir / "99-wigidash.rules").write_text(
+        'SUBSYSTEM=="usb", ATTR{idVendor}=="28da", ATTR{idProduct}=="ef01", TAG+="uaccess"\n'
+    )
+
+    assert wigidash_usb._udev_rule_exists(0x28DA, 0xEF01, rules_dirs=(str(rules_dir),)) is True
+
+
+def test_udev_rule_exists_false_when_no_matching_rule(tmp_path):
+    rules_dir = tmp_path / "rules.d"
+    rules_dir.mkdir()
+    (rules_dir / "50-other-device.rules").write_text(
+        'SUBSYSTEM=="usb", ATTR{idVendor}=="1234", ATTR{idProduct}=="5678", TAG+="uaccess"\n'
+    )
+
+    assert wigidash_usb._udev_rule_exists(0x28DA, 0xEF01, rules_dirs=(str(rules_dir),)) is False
+
+
+def test_udev_rule_exists_false_when_dir_missing(tmp_path):
+    missing_dir = tmp_path / "does_not_exist"
+    assert wigidash_usb._udev_rule_exists(0x28DA, 0xEF01, rules_dirs=(str(missing_dir),)) is False
+
+
+def test_check_linux_usb_permissions_skipped_on_non_linux(monkeypatch):
+    monkeypatch.setattr(wigidash_usb, "is_linux", False)
+    ok, hint = wigidash_usb.check_linux_usb_permissions()
+    assert ok is True
+    assert hint is None
+
+
+def test_check_linux_usb_permissions_ok_as_root(monkeypatch):
+    monkeypatch.setattr(wigidash_usb, "is_linux", True)
+    monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+    ok, hint = wigidash_usb.check_linux_usb_permissions()
+    assert ok is True
+    assert hint is None
+
+
+def test_check_linux_usb_permissions_ok_with_matching_rule(monkeypatch):
+    monkeypatch.setattr(wigidash_usb, "is_linux", True)
+    monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
+    monkeypatch.setattr(wigidash_usb, "_udev_rule_exists", lambda *a, **kw: True)
+    ok, hint = wigidash_usb.check_linux_usb_permissions()
+    assert ok is True
+    assert hint is None
+
+
+def test_check_linux_usb_permissions_fails_with_actionable_message(monkeypatch):
+    monkeypatch.setattr(wigidash_usb, "is_linux", True)
+    monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
+    monkeypatch.setattr(wigidash_usb, "_udev_rule_exists", lambda *a, **kw: False)
+    monkeypatch.setattr(wigidash_usb.usb.core, "find", lambda **kw: [])
+
+    ok, hint = wigidash_usb.check_linux_usb_permissions(0x28DA, 0xEF01)
+    assert ok is False
+    assert "udev" in hint.lower()
+    assert "28da" in hint.lower()
+    assert "ef01" in hint.lower()
+
+
+def test_check_linux_usb_permissions_ok_when_device_node_accessible(monkeypatch):
+    """No udev rule found, but the device node is already accessible (e.g.
+    user granted access some other way) — should not report a failure."""
+    monkeypatch.setattr(wigidash_usb, "is_linux", True)
+    monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
+    monkeypatch.setattr(wigidash_usb, "_udev_rule_exists", lambda *a, **kw: False)
+
+    class FakeDev:
+        bus = 1
+        address = 5
+
+    monkeypatch.setattr(wigidash_usb.usb.core, "find", lambda **kw: [FakeDev()])
+    monkeypatch.setattr(os.path, "exists", lambda p: True)
+    monkeypatch.setattr(os, "access", lambda p, m: True)
+
+    ok, hint = wigidash_usb.check_linux_usb_permissions(0x28DA, 0xEF01)
+    assert ok is True
+    assert hint is None
+
+
+def test_is_permission_error_detects_known_signals():
+    assert wigidash_usb._is_permission_error(Exception("[Errno 13] Access denied")) is True
+    assert wigidash_usb._is_permission_error(Exception("Operation not permitted")) is True
+    assert wigidash_usb._is_permission_error(Exception("Resource busy")) is False
 

--- a/benchlab/wigidash/wigidash_manager.py
+++ b/benchlab/wigidash/wigidash_manager.py
@@ -31,11 +31,13 @@ class WigidashManager:
         self.shutdown_event = threading.Event()
         self.shutdown_barrier = None
         self.datasource = datasource  # Already-connected DataSourceManager
+        self._telemetry_lock = threading.Lock()
 
     # ----------------- BENCHLAB DEVICE MANAGEMENT ----------------- #
     def get_available_benchlabs(self, log_info=True):
         """Query the datasource for available Benchlab devices."""
         devices = []
+        query_succeeded = False
         try:
             raw = self.datasource.list_devices()
             if isinstance(raw, dict):
@@ -44,6 +46,7 @@ class WigidashManager:
                            for uid, info in raw.items()]
             else:
                 devices = list(raw)
+            query_succeeded = True
         except Exception as e:
             logger.warning(f"list_devices failed: {e}")
 
@@ -56,6 +59,14 @@ class WigidashManager:
             else:
                 self.benchlab_devices[port]["uid"] = uid
                 self.benchlab_devices[port]["firmware"] = fw
+
+        # Prune ports no longer reported by the data source, so a disconnected
+        # device doesn't linger forever with stale UID/firmware/in_use state.
+        if query_succeeded:
+            current_ports = {d["port"] for d in devices}
+            for stale_port in set(self.benchlab_devices) - current_ports:
+                del self.benchlab_devices[stale_port]
+                self.telemetry_contexts.pop(stale_port, None)
 
         all_devices = [
             {"port": port, "uid": info["uid"], "in_use": info["in_use"]}
@@ -83,75 +94,76 @@ class WigidashManager:
             logger.warning(f"Cannot start telemetry: unknown port {port}")
             return
 
-        # ------------------------------------------------
-        # CASE 1: Telemetry already running for this port
-        # ------------------------------------------------
-        if port in self.telemetry_contexts:
-            ctx = self.telemetry_contexts[port]
+        with self._telemetry_lock:
+            # ------------------------------------------------
+            # CASE 1: Telemetry already running for this port
+            # ------------------------------------------------
+            if port in self.telemetry_contexts:
+                ctx = self.telemetry_contexts[port]
 
-            logger.info(
-                f"Selected device {port} is already in use. Using existing telemetry."
+                logger.info(
+                    f"Selected device {port} is already in use. Using existing telemetry."
+                )
+
+                session.ser = ctx.ser
+                session.device_info = ctx.device_info
+                session.uid = ctx.uid
+                session.telemetry_history = ctx.history
+                session.history = ctx.history
+                session.selected_port = port
+                session.telemetry_context = ctx
+
+                ctx.sessions.append(session)
+                return
+
+            # ------------------------------------------------
+            # CASE 2: First session → start telemetry
+            # ------------------------------------------------
+            self.benchlab_devices[port]["in_use"] = True
+            uid = self.benchlab_devices[port]["uid"]
+            history = self.telemetry_histories.setdefault(uid, TelemetryHistory())
+
+            # Get device info from datasource
+            device_info = {}
+            try:
+                self.datasource.select_device(uid)
+                snap = self.datasource.snapshot()
+                device_info = snap.get("device_info") or snap.get("all_devices", {}).get(uid, {})
+            except Exception as e:
+                logger.warning(f"Could not get device info for {uid}: {e}")
+
+            ctx = TelemetryContext(
+                port=port,
+                ser=None,
+                device_info=device_info,
+                uid=uid,
+                history=history,
             )
+            ctx.sessions = [session]
+            self.telemetry_contexts[port] = ctx
 
-            session.ser = ctx.ser
-            session.device_info = ctx.device_info
-            session.uid = ctx.uid
-            session.telemetry_history = ctx.history
-            session.history = ctx.history
+            session.ser = None
+            session.device_info = device_info
+            session.uid = uid
+            session.telemetry_history = history
+            session.history = history
             session.selected_port = port
-            session.telemetry_context = ctx
 
-            ctx.sessions.append(session)
-            return
+            def telemetry_loop():
+                while not self.shutdown_event.is_set():
+                    try:
+                        self.datasource.select_device(uid)
+                        snap = self.datasource.snapshot()
+                        data = (snap.get("sensor_data")
+                                or snap.get("all_telemetry", {}).get(uid)
+                                or {})
+                        if data:
+                            telemetry_step(ctx, device_info=device_info, sensor_struct=data)
+                    except Exception as e:
+                        logger.warning(f"Telemetry error on {port}: {e}")
+                    time.sleep(0.1)
 
-        # ------------------------------------------------
-        # CASE 2: First session → start telemetry
-        # ------------------------------------------------
-        self.benchlab_devices[port]["in_use"] = True
-        uid = self.benchlab_devices[port]["uid"]
-        history = self.telemetry_histories.setdefault(uid, TelemetryHistory())
-
-        # Get device info from datasource
-        device_info = {}
-        try:
-            self.datasource.select_device(uid)
-            snap = self.datasource.snapshot()
-            device_info = snap.get("device_info") or snap.get("all_devices", {}).get(uid, {})
-        except Exception as e:
-            logger.warning(f"Could not get device info for {uid}: {e}")
-
-        ctx = TelemetryContext(
-            port=port,
-            ser=None,
-            device_info=device_info,
-            uid=uid,
-            history=history,
-        )
-        ctx.sessions = [session]
-        self.telemetry_contexts[port] = ctx
-
-        session.ser = None
-        session.device_info = device_info
-        session.uid = uid
-        session.telemetry_history = history
-        session.history = history
-        session.selected_port = port
-
-        def telemetry_loop():
-            while not self.shutdown_event.is_set():
-                try:
-                    self.datasource.select_device(uid)
-                    snap = self.datasource.snapshot()
-                    data = (snap.get("sensor_data")
-                            or snap.get("all_telemetry", {}).get(uid)
-                            or {})
-                    if data:
-                        telemetry_step(ctx, device_info=device_info, sensor_struct=data)
-                except Exception as e:
-                    logger.warning(f"Telemetry error on {port}: {e}")
-                time.sleep(0.1)
-
-        threading.Thread(target=telemetry_loop, daemon=True).start()
+            threading.Thread(target=telemetry_loop, daemon=True).start()
 
 
     # ----------------- SESSION MANAGEMENT ----------------- #

--- a/benchlab/wigidash/wigidash_session.py
+++ b/benchlab/wigidash/wigidash_session.py
@@ -144,6 +144,10 @@ class BenchlabWigiSession:
             return True
         except Exception as e:
             logger.error(f"Failed to initialize Wigidash {self.usb_device.serial}: {e}")
+            try:
+                self.usb_device.disconnect()
+            except Exception:
+                pass
             return False
 
 
@@ -286,6 +290,11 @@ class BenchlabWigiSession:
                 self.wigidash.clear_page(0)
             except Exception:
                 pass
+        if self.usb_device:
+            try:
+                self.usb_device.disconnect()
+            except Exception as e:
+                logger.warning(f"Error disconnecting USB device: {e}")
         logger.info(f"Wigidash session {self.usb_device.serial} cleaned up.")
 
 

--- a/benchlab/wigidash/wigidash_usb.py
+++ b/benchlab/wigidash/wigidash_usb.py
@@ -1,7 +1,9 @@
 # wigidash_usb.py
 
+import glob
 import logging
 import os
+import re
 import sys
 import usb.core
 import usb.util
@@ -12,11 +14,101 @@ is_linux = sys.platform.startswith("linux")
 
 logger = get_logger("WigidashUsb")
 
+_PERMISSION_ERROR_SIGNALS = (
+    "access denied",
+    "insufficient permissions",
+    "errno 13",
+    "operation not permitted",
+    "permission denied",
+)
+
+_UDEV_RULES_DIRS = ("/etc/udev/rules.d", "/usr/lib/udev/rules.d", "/lib/udev/rules.d")
+
+
+def _udev_rule_hint(vendor_id, product_id):
+    """Return the udev rule text + setup steps for granting non-root USB access."""
+    return (
+        f'Create /etc/udev/rules.d/99-wigidash.rules with:\n'
+        f'  SUBSYSTEM=="usb", ATTR{{idVendor}}=="{vendor_id:04x}", '
+        f'ATTR{{idProduct}}=="{product_id:04x}", TAG+="uaccess"\n'
+        f"Then run: sudo udevadm control --reload-rules && sudo udevadm trigger"
+    )
+
+
+def _udev_rule_exists(vendor_id, product_id, rules_dirs=_UDEV_RULES_DIRS):
+    """Best-effort scan of udev rule files for one referencing this VID:PID."""
+    vid_hex = f"{vendor_id:04x}"
+    pid_hex = f"{product_id:04x}"
+    pattern = re.compile(
+        rf'idVendor.{{0,5}}{vid_hex}.{{0,80}}idProduct.{{0,5}}{pid_hex}'
+        rf'|idProduct.{{0,5}}{pid_hex}.{{0,80}}idVendor.{{0,5}}{vid_hex}',
+        re.IGNORECASE,
+    )
+    for rules_dir in rules_dirs:
+        for path in glob.glob(os.path.join(rules_dir, "*.rules")):
+            try:
+                with open(path, "r", errors="ignore") as f:
+                    if pattern.search(f.read()):
+                        return True
+            except OSError:
+                continue
+    return False
+
+
+def check_linux_usb_permissions(vendor_id=0x28DA, product_id=0xEF01):
+    """
+    Best-effort check that the current user can access the WigiDash USB
+    device without root (via an existing udev rule, or an already-accessible
+    device node). Linux-only diagnostic — never a hard gate.
+
+    Returns (True, None) if access looks fine or the check is inconclusive,
+    (False, <actionable message>) if it looks like it will fail.
+    """
+    if not is_linux:
+        return True, None
+
+    if os.geteuid() == 0:
+        return True, None
+
+    if _udev_rule_exists(vendor_id, product_id):
+        return True, None
+
+    # No matching rule found — see if a device node is nonetheless already
+    # accessible (e.g. user is in the right group via some other mechanism).
+    try:
+        found = usb.core.find(idVendor=vendor_id, idProduct=product_id, find_all=True)
+        for dev in found:
+            bus, addr = getattr(dev, "bus", None), getattr(dev, "address", None)
+            if bus is None or addr is None:
+                continue
+            node = f"/dev/bus/usb/{bus:03d}/{addr:03d}"
+            if os.path.exists(node) and os.access(node, os.R_OK | os.W_OK):
+                return True, None
+    except Exception:
+        pass  # inconclusive — fall through to the actionable warning
+
+    return False, (
+        "No udev rule found granting non-root access to the WigiDash "
+        f"(VID:0x{vendor_id:04X}, PID:0x{product_id:04X}). "
+        + _udev_rule_hint(vendor_id, product_id)
+    )
+
+
+def _is_permission_error(exc) -> bool:
+    msg = str(exc).lower()
+    return any(signal in msg for signal in _PERMISSION_ERROR_SIGNALS)
+
+
 def scan_wigidash(vendor_id=0x28DA, product_id=0xEF01):
     """
     Scan for all connected Wigidash USB devices.
     Returns a list of USBDevice instances (already connected).
     """
+    if is_linux:
+        ok, hint = check_linux_usb_permissions(vendor_id, product_id)
+        if not ok:
+            logger.warning(f"WigiDash USB access may be misconfigured: {hint}")
+
     devices = []
     found = usb.core.find(idVendor=vendor_id, idProduct=product_id, find_all=True)
     for dev in found:
@@ -28,7 +120,13 @@ def scan_wigidash(vendor_id=0x28DA, product_id=0xEF01):
             logger.info(f"Wigidash device found and configured: VID:0x{vendor_id:04X}, PID:0x{product_id:04X}, Serial: {serial}")
             devices.append(usb_dev)
         except usb.core.USBError as e:
-            logger.warning(f"Failed to configure device {dev}: {e}")
+            if is_linux and _is_permission_error(e):
+                logger.warning(
+                    f"Failed to configure device {dev}: {e}. "
+                    f"{_udev_rule_hint(vendor_id, product_id)}"
+                )
+            else:
+                logger.warning(f"Failed to configure device {dev}: {e}")
     return devices
 
 class USBDevice:
@@ -45,7 +143,13 @@ class USBDevice:
             self.dev.set_configuration()
             logger.info(f"USB device configured successfully, serial: {self.serial}")
         except usb.core.USBError as e:
-            logger.warning(f"USB set_configuration failed (ignored): {e}")
+            if is_linux and _is_permission_error(e):
+                logger.warning(
+                    f"USB set_configuration failed (ignored): {e}. "
+                    f"{_udev_rule_hint(self.vendor_id, self.product_id)}"
+                )
+            else:
+                logger.warning(f"USB set_configuration failed (ignored): {e}")
 
     def disconnect(self):
         """Cleanup USB resources"""

--- a/benchlab/wigidash/wigidash_usb.py
+++ b/benchlab/wigidash/wigidash_usb.py
@@ -11,8 +11,20 @@ import usb.util
 from benchlab.wigidash.benchlab_utils import get_logger
 
 is_linux = sys.platform.startswith("linux")
+is_windows = sys.platform.startswith("win")
 
 logger = get_logger("WigidashUsb")
+
+_usb_backend = None
+if is_windows:
+    try:
+        import libusb_package
+        _usb_backend = libusb_package.get_libusb1_backend()
+        logger.debug("Using bundled libusb-package backend for pyusb")
+    except Exception as e:
+        # Fall back to pyusb's normal backend discovery (e.g. a system-wide
+        # libusb-1.0.dll on PATH) if libusb-package isn't installed/usable.
+        logger.debug(f"libusb-package backend unavailable, falling back to default discovery: {e}")
 
 _PERMISSION_ERROR_SIGNALS = (
     "access denied",
@@ -110,7 +122,10 @@ def scan_wigidash(vendor_id=0x28DA, product_id=0xEF01):
             logger.warning(f"WigiDash USB access may be misconfigured: {hint}")
 
     devices = []
-    found = usb.core.find(idVendor=vendor_id, idProduct=product_id, find_all=True)
+    find_kwargs = {"idVendor": vendor_id, "idProduct": product_id, "find_all": True}
+    if _usb_backend is not None:
+        find_kwargs["backend"] = _usb_backend
+    found = usb.core.find(**find_kwargs)
     for dev in found:
         try:
             dev.set_configuration()


### PR DESCRIPTION
Closes #22

## Summary
Bug sweep of `benchlab/wigidash`, continuing the repo-wide sweep after csv_log, tui, restapi, graph, and hwinfo. Largest module swept so far — used 3 parallel exploration passes (USB/session layer, UI/rendering layer, fleet/telemetry/utils layer) then personally verified every finding against the actual source before fixing.

- **USB resource leak**: `wigidash_session.py`'s `cleanup()` never called `usb_device.disconnect()` on any path, including `connect_wigidash()` failure — leaking USB/libusb handles on every session end. A `shutdown_wigidash()` helper already existed with the right cleanup sequence but was dead code with a latent `usb_dev`/`usb_device` attribute mismatch bug; fixed that too so it isn't silently broken for any future caller.
- **Telemetry race condition**: `start_telemetry`'s check-then-act on `telemetry_contexts` had no lock — two sessions selecting the same port near-simultaneously could spawn duplicate polling threads, orphaning one forever. Added a lock around the check-and-create block.
- **Stale fleet state**: `get_available_benchlabs` only ever added/updated devices, never pruned ports that disconnected. Fixed to prune vanished ports (skipped on a transient `list_devices()` failure so a momentary error doesn't wipe out known devices). Same bug class already fixed in restapi and hwinfo sweeps.
- **Dead touch debounce**: Overview, Graph, and Fleet pages all compared millisecond timestamps against a threshold of `0.1` (0.1ms, not the intended ~100-150ms), and two of the three pages never even set the timestamp being compared, making the check permanently dead code. Fixed the threshold to 150ms and wired up `last_touch_time` tracking on all three pages.
- **Dead code**: removed a `try: self.stop() except: pass` in `benchlab_overview.py` — `stop()` doesn't exist on the class, always raised, silently swallowed.
- **Shared-state mutation**: `telemetry_step` mutated the caller's sensor dict (and nested `Fans`/`Vin` structures) in place instead of working on a copy.
- **Stale README**: corrected launch instructions from a nonexistent `wigidash_launcher.py` to the real entry point, `python benchlab.py -wigidash`.
- Added `benchlab/wigidash/test_wigidash.py` (previously zero coverage) and wired it into `pycore-compat.yml`.

Note: full hardware-in-the-loop testing isn't feasible in CI (real WigiDash USB device + BenchLab hardware required), but all the fixes above are pure-Python logic bugs, unit-tested with fakes/mocks.

## Test plan
- [x] `ast.parse` syntax check on all modified files
- [x] New pytest suite (`test_wigidash.py`) passes locally: stale-port pruning (including the transient-failure-doesn't-wipe-state case), telemetry lock preventing duplicate contexts under concurrent calls, `telemetry_step` not mutating the caller's dict, debounce rejecting a touch 10ms after the previous one and accepting one 200ms later
- [x] Verified the debounce regression test actually catches the bug: reverted the fix locally, confirmed the test fails, restored the fix, confirmed it passes again
- [x] Verified all wigidash submodules import cleanly without a physical USB device attached
- [ ] No physical WigiDash/BenchLab-in-the-loop CI exists, so full interactive verification (touch input, USB reconnect cycles, multi-device session races) was not possible; the above scripted checks exercise the same code paths headlessly with fakes