### PR TITLE
Fix MQTTDataSource hardcoded topic prefix, add protocol config + tests

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Test - mqtt publisher
         run: pytest benchlab/mqtt/test_mqtt_publisher.py -v
 
+      - name: Test - mqtt datasource
+        run: pytest tests/test_mqtt_datasource.py -v
+
   latest:
     name: Import + test against latest pycore (PyPI)
     runs-on: windows-latest
@@ -128,3 +131,6 @@ jobs:
 
       - name: Test - mqtt publisher
         run: pytest benchlab/mqtt/test_mqtt_publisher.py -v
+
+      - name: Test - mqtt datasource
+        run: pytest tests/test_mqtt_datasource.py -v

--- a/benchlab/core/datasource.py
+++ b/benchlab/core/datasource.py
@@ -410,11 +410,53 @@ class FastAPIDataSource(DataSource):
         return "fastapi"
 
 
+def resolve_mqtt_protocol(value, mqtt_module):
+    """Resolve *value* to one of paho's MQTTv31/MQTTv311/MQTTv5 int constants.
+
+    Accepts the int constants themselves, or common name/version strings
+    (case-insensitive, e.g. "MQTTv5", "v3.1.1", "5"). Raises ValueError
+    immediately on anything unrecognized, so a bad MQTT_PROTOCOL value is
+    caught at startup instead of crashing silently inside paho's background
+    network thread once a broker actually accepts the connection.
+
+    *mqtt_module* is the imported ``paho.mqtt.client`` module, passed in
+    rather than imported at module scope here since paho-mqtt is an
+    optional/lazy dependency of this module (see MQTTDataSource.__init__).
+    """
+    aliases = {
+        "3": mqtt_module.MQTTv31,
+        "3.1": mqtt_module.MQTTv31,
+        "v3.1": mqtt_module.MQTTv31,
+        "mqttv31": mqtt_module.MQTTv31,
+        "4": mqtt_module.MQTTv311,
+        "3.1.1": mqtt_module.MQTTv311,
+        "v3.1.1": mqtt_module.MQTTv311,
+        "mqttv311": mqtt_module.MQTTv311,
+        "mqttv3.1.1": mqtt_module.MQTTv311,
+        "5": mqtt_module.MQTTv5,
+        "v5": mqtt_module.MQTTv5,
+        "mqttv5": mqtt_module.MQTTv5,
+    }
+
+    if value in (mqtt_module.MQTTv31, mqtt_module.MQTTv311, mqtt_module.MQTTv5):
+        return value
+
+    key = str(value).strip().lower()
+    if key in aliases:
+        return aliases[key]
+
+    raise ValueError(
+        f"Unrecognized MQTT_PROTOCOL value: {value!r}. "
+        f"Expected one of: MQTTv31 (3.1), MQTTv311 (3.1.1, default), MQTTv5."
+    )
+
+
 class MQTTDataSource(DataSource):
     """Data source that subscribes to an MQTT broker."""
 
-    def __init__(self, *, config: Optional["MQTTConfig"] = None, broker: str = "localhost", port: int = 1883, topic_prefix: str = "benchlab", timeout: float = 5.0):
+    def __init__(self, *, config: Optional["MQTTConfig"] = None, broker: str = "localhost", port: int = 1883, topic_prefix: str = "benchlab", timeout: float = 5.0, protocol: Optional[str] = None):
         from .config import MQTTConfig
+        import os
 
         if config is None:
             config = MQTTConfig(broker=broker, port=port, topic_prefix=topic_prefix, timeout=timeout)
@@ -422,37 +464,42 @@ class MQTTDataSource(DataSource):
         self.port = config.port
         self.topic_prefix = config.topic_prefix
         self.timeout = config.timeout
+        # Falls back to MQTT_PROTOCOL env var (same variable the publisher
+        # side reads) so both producer and consumer resolve consistently,
+        # then to MQTTv311 if neither is set.
+        self._protocol_setting = protocol if protocol is not None else os.getenv("MQTT_PROTOCOL", "MQTTv311")
         self._connected = False
         self._client = None
         self._lock = threading.Lock()
         self._latest_data: Dict[str, Dict[str, Any]] = {}
         self._device_info: Dict[str, Dict[str, Any]] = {}
         self._stop_event = threading.Event()
-        
+
         try:
             import paho.mqtt.client as mqtt
             self._mqtt = mqtt
         except ImportError:
             logger.error("paho-mqtt library not available")
             self._mqtt = None
-    
+
     @retry(RetryPolicy(max_retries=3, backoff_factor=2.0, base_delay=0.5, allowed_exceptions=(Exception,)))
     def connect(self) -> bool:
         if self._mqtt is None:
             return False
-        
+
         try:
+            resolved_protocol = resolve_mqtt_protocol(self._protocol_setting, self._mqtt)
             try:
                 from paho.mqtt.enums import CallbackAPIVersion
                 self._client = self._mqtt.Client(
                     callback_api_version=CallbackAPIVersion.VERSION2,
                     client_id=f"benchlab_datasource_{int(time.time())}",
-                    protocol=self._mqtt.MQTTv5 if hasattr(self._mqtt, 'MQTTv5') else self._mqtt.MQTTv311
+                    protocol=resolved_protocol
                 )
             except (ImportError, TypeError):
                 self._client = self._mqtt.Client(
                     client_id=f"benchlab_datasource_{int(time.time())}",
-                    protocol=self._mqtt.MQTTv311
+                    protocol=resolved_protocol
                 )
             self._client.on_connect = self._on_connect
             self._client.on_message = self._on_message
@@ -526,7 +573,7 @@ class MQTTDataSource(DataSource):
         try:
             payload = json.loads(msg.payload.decode('utf-8'))
             parts = msg.topic.split('/')
-            if len(parts) >= 3 and parts[0] == 'benchlab':
+            if len(parts) >= 3 and parts[0] == self.topic_prefix:
                 uid = parts[1]
                 msg_type = parts[2] if len(parts) > 2 else None
                 

--- a/benchlab/mqtt/mqtt_publisher.py
+++ b/benchlab/mqtt/mqtt_publisher.py
@@ -19,6 +19,9 @@ from benchlab.core.device_registry import DeviceRegistry
 # benchlab_pycore.core.serial_io has no connection-opening helper; use the
 # local wrapper instead (see benchlab.core.shared_serial).
 from benchlab.core.shared_serial import open_serial_connection
+# Shared with benchlab.core.datasource.MQTTDataSource so both the publisher
+# and consumer sides resolve MQTT_PROTOCOL the same way.
+from benchlab.core.datasource import resolve_mqtt_protocol as _resolve_mqtt_protocol
 
 MQTTV5_REASON_CODES = {
     0:  "Success",
@@ -67,42 +70,15 @@ logger.addHandler(handler)
 global_stop_event = threading.Event()
 device_stop_events = {}  # {uid: threading.Event}
 
-_MQTT_PROTOCOL_ALIASES = {
-    "3": mqtt.MQTTv31,
-    "3.1": mqtt.MQTTv31,
-    "v3.1": mqtt.MQTTv31,
-    "mqttv31": mqtt.MQTTv31,
-    "4": mqtt.MQTTv311,
-    "3.1.1": mqtt.MQTTv311,
-    "v3.1.1": mqtt.MQTTv311,
-    "mqttv311": mqtt.MQTTv311,
-    "mqttv3.1.1": mqtt.MQTTv311,
-    "5": mqtt.MQTTv5,
-    "v5": mqtt.MQTTv5,
-    "mqttv5": mqtt.MQTTv5,
-}
-
-
 def resolve_mqtt_protocol(value):
     """Resolve *value* to one of paho's MQTTv31/MQTTv311/MQTTv5 int constants.
 
-    Accepts the int constants themselves, or common name/version strings
-    (case-insensitive, e.g. "MQTTv5", "v3.1.1", "5"). Raises ValueError
-    immediately on anything unrecognized, so a bad MQTT_PROTOCOL value is
-    caught at startup instead of crashing silently inside paho's background
-    network thread once a broker actually accepts the connection.
+    Thin wrapper around benchlab.core.datasource.resolve_mqtt_protocol,
+    kept here (with this module's paho import already available) so both
+    the publisher and MQTTDataSource share one resolver implementation.
+    See that function's docstring for accepted value formats.
     """
-    if value in (mqtt.MQTTv31, mqtt.MQTTv311, mqtt.MQTTv5):
-        return value
-
-    key = str(value).strip().lower()
-    if key in _MQTT_PROTOCOL_ALIASES:
-        return _MQTT_PROTOCOL_ALIASES[key]
-
-    raise ValueError(
-        f"Unrecognized MQTT_PROTOCOL value: {value!r}. "
-        f"Expected one of: MQTTv31 (3.1), MQTTv311 (3.1.1, default), MQTTv5."
-    )
+    return _resolve_mqtt_protocol(value, mqtt)
 
 
 def load_local_config(filename="mqtt.config"):

--- a/tests/test_mqtt_datasource.py
+++ b/tests/test_mqtt_datasource.py
@@ -1,0 +1,104 @@
+"""Non-hardware regression tests for benchlab.core.datasource.MQTTDataSource.
+
+These tests exercise MQTTDataSource's message-parsing and protocol
+resolution logic directly — no real MQTT broker or BenchLab hardware is
+required (unlike tests/test_data_sources.py::TestMQTTSource, which needs
+both and is excluded from CI). Cover the topic-prefix bug found while
+auditing MQTT test coverage: _on_message filtered incoming messages
+against a hardcoded "benchlab" literal instead of the configurable
+self.topic_prefix, silently dropping every message whenever a non-default
+MQTT_TOPIC_PREFIX was set.
+"""
+
+import json
+
+import pytest
+
+from benchlab.core.datasource import MQTTDataSource, resolve_mqtt_protocol
+
+try:
+    import paho.mqtt.client as mqtt
+    HAS_PAHO = True
+except ImportError:
+    mqtt = None
+    HAS_PAHO = False
+
+pytestmark = pytest.mark.skipif(not HAS_PAHO, reason="paho-mqtt not available")
+
+
+class FakeMsg:
+    def __init__(self, topic, payload):
+        self.topic = topic
+        self.payload = json.dumps(payload).encode("utf-8")
+
+
+def test_on_message_default_topic_prefix():
+    ds = MQTTDataSource(broker="localhost")
+    ds._on_message(None, None, FakeMsg("benchlab/UID1/telemetry", {"temp": 42.0}))
+    assert ds._latest_data["UID1"] == {"temp": 42.0}
+
+
+def test_on_message_custom_topic_prefix():
+    """Regression test: _on_message used to hardcode 'benchlab' as the
+    prefix check regardless of self.topic_prefix, so a custom prefix
+    silently dropped every message."""
+    ds = MQTTDataSource(broker="localhost", topic_prefix="custom-prefix")
+    ds._on_message(None, None, FakeMsg("custom-prefix/UID2/telemetry", {"temp": 10.0}))
+    assert ds._latest_data["UID2"] == {"temp": 10.0}
+
+
+def test_on_message_info_payload():
+    ds = MQTTDataSource(broker="localhost", topic_prefix="custom-prefix")
+    ds._on_message(None, None, FakeMsg("custom-prefix/UID3/info", {"firmware": "1.2.3"}))
+    assert ds._device_info["UID3"] == {"firmware": "1.2.3"}
+
+
+def test_on_message_ignores_mismatched_prefix():
+    ds = MQTTDataSource(broker="localhost", topic_prefix="custom-prefix")
+    ds._on_message(None, None, FakeMsg("wrong-prefix/UID4/telemetry", {"temp": 1.0}))
+    assert "UID4" not in ds._latest_data
+
+
+def test_on_message_ignores_malformed_topic():
+    ds = MQTTDataSource(broker="localhost")
+    ds._on_message(None, None, FakeMsg("benchlab/onlytwo", {"temp": 1.0}))
+    assert ds._latest_data == {}
+
+
+def test_on_message_does_not_raise_on_bad_json():
+    ds = MQTTDataSource(broker="localhost")
+
+    class BadMsg:
+        topic = "benchlab/UID5/telemetry"
+        payload = b"not json"
+
+    ds._on_message(None, None, BadMsg())  # must not raise
+    assert "UID5" not in ds._latest_data
+
+
+# ----------------------------------------------------------------------
+# Protocol resolution
+# ----------------------------------------------------------------------
+
+def test_protocol_defaults_to_v311_when_unset(monkeypatch):
+    monkeypatch.delenv("MQTT_PROTOCOL", raising=False)
+    ds = MQTTDataSource(broker="localhost")
+    assert resolve_mqtt_protocol(ds._protocol_setting, mqtt) == mqtt.MQTTv311
+
+
+def test_protocol_reads_env_var(monkeypatch):
+    monkeypatch.setenv("MQTT_PROTOCOL", "MQTTv5")
+    ds = MQTTDataSource(broker="localhost")
+    assert resolve_mqtt_protocol(ds._protocol_setting, mqtt) == mqtt.MQTTv5
+
+
+def test_protocol_explicit_param_overrides_env(monkeypatch):
+    monkeypatch.setenv("MQTT_PROTOCOL", "MQTTv5")
+    ds = MQTTDataSource(broker="localhost", protocol="v3.1")
+    assert resolve_mqtt_protocol(ds._protocol_setting, mqtt) == mqtt.MQTTv31
+
+
+def test_protocol_invalid_setting_raises_on_connect_attempt():
+    ds = MQTTDataSource(broker="localhost", protocol="garbage")
+    with pytest.raises(ValueError, match="Unrecognized MQTT_PROTOCOL"):
+        resolve_mqtt_protocol(ds._protocol_setting, mqtt)


### PR DESCRIPTION
Stacked on #26 (still open, itself stacked on #25) — targets `fix/mqtt-protocol-broker-followup` so the diff here is just the incremental follow-up. Rebase onto `dev-pycore` once the earlier PRs merge.

## Summary
While answering "did we add MQTT as a data source to the test suite," found `MQTTDataSource` (`benchlab/core/datasource.py`) — the consumer class backing `--source mqtt`/`mqtt_custom`, distinct from `mqtt_publisher.py` which was already covered in #25/#26 — had zero test coverage, and a real bug surfaced while checking it.

- **`_on_message` filtered incoming messages against a hardcoded `'benchlab'` literal instead of the configurable `self.topic_prefix`.** `_on_connect` correctly subscribes using `topic_prefix`, but the message handler never matched it, so any non-default `MQTT_TOPIC_PREFIX` silently dropped every single message — `list_devices()`/`get_telemetry()` would just stay empty forever with no error anywhere. Confirmed this is a live, reachable path: `benchlab/hwinfo/hwinfo_export.py` passes `topic_prefix=os.environ.get("MQTT_TOPIC_PREFIX", "benchlab")` through to datasource construction, and `datasource_manager.py` forwards `topic_prefix` from kwargs too.
- **`MQTTDataSource.connect()` hardcoded protocol to MQTTv5-with-fallback**, inconsistent with `mqtt_publisher.py`'s now-configurable `MQTT_PROTOCOL` (#26). Relocated `resolve_mqtt_protocol()` into `benchlab/core/datasource.py` (`mqtt_publisher.py` now re-exports a thin wrapper, so its existing public API keeps working unchanged) so both the producer and consumer sides resolve `MQTT_PROTOCOL` the same way.
- Added `tests/test_mqtt_datasource.py` (previously zero coverage) covering topic prefix filtering (default and custom — the regression test for the bug above), malformed topics, bad JSON payloads, and protocol resolution. No real broker needed.
- Wired the new test file into `pycore-compat.yml`.

## Test plan
- [x] `ast.parse` syntax check on all modified files
- [x] New pytest suite (`test_mqtt_datasource.py`) passes locally: 10/10
- [x] Verified the custom-prefix regression test actually catches the bug: reverted the fix locally, confirmed the test fails with `KeyError`, restored the fix, confirmed it passes again
- [x] Confirmed `resolve_mqtt_protocol` still importable unchanged from `benchlab.mqtt.mqtt_publisher` after the relocation (no breaking change to #26's public API)
- [x] No circular import introduced (`benchlab.core.datasource` has no dependency on `benchlab.mqtt`); confirmed both modules still import cleanly
- [x] Full existing mqtt-related test suite re-run (40 tests across `test_mqtt_datasource.py` + `test_mqtt_publisher.py`), no regressions; full sweep regression run (65 tests across mqtt/wigidash/hwinfo/graph) also clean
- [ ] No real MQTT broker in CI, so full interactive verification (actual pub/sub with a non-default topic prefix against a live broker) was not possible; the above scripted checks exercise the same code paths headlessly with fake messages