### PR TITLE
Fix vu bug sweep: false-success reporting, config write race, orphaned processes

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -28,6 +28,7 @@ jobs:
           pip install -r benchlab/csv_log/requirements.txt
           pip install -r benchlab/graph/requirements.txt
           pip install -r benchlab/wigidash/requirements.txt
+          pip install -r benchlab/vu/requirements.txt
           pip install pytest
 
       - name: Import smoke test
@@ -41,7 +42,9 @@ jobs:
           benchlab.wigidash.wigidash_manager, benchlab.wigidash.wigidash_usb,
           benchlab.wigidash.wigidash_device, benchlab.wigidash.wigidash_session,
           benchlab.wigidash.benchlab_telemetry, benchlab.wigidash.benchlab_fleet,
-          benchlab.wigidash.benchlab_overview, benchlab.wigidash.benchlab_graph"
+          benchlab.wigidash.benchlab_overview, benchlab.wigidash.benchlab_graph,
+          benchlab.vu.vu_server_manager, benchlab.vu.vu_server_config,
+          benchlab.vu.devices, benchlab.vu.vu_tui, benchlab.vu.vu_updater"
 
       - name: Test - core data sources
         run: pytest tests/test_data_sources.py -v -k "not mqtt"
@@ -72,6 +75,15 @@ jobs:
 
       - name: Test - mqtt datasource
         run: pytest tests/test_mqtt_datasource.py -v
+
+      - name: Test - vu server manager
+        run: pytest benchlab/vu/test_vu_server_manager.py -v
+
+      - name: Test - vu server config
+        run: pytest benchlab/vu/test_vu_server_config.py -v
+
+      - name: Test - vu devices config loading
+        run: pytest benchlab/vu/test_devices.py -v
 
   latest:
     name: Import + test against latest pycore (PyPI)
@@ -89,6 +101,7 @@ jobs:
           pip install -r benchlab/csv_log/requirements.txt
           pip install -r benchlab/graph/requirements.txt
           pip install -r benchlab/wigidash/requirements.txt
+          pip install -r benchlab/vu/requirements.txt
           pip install pytest
           pip install --upgrade benchlab-pycore
 
@@ -103,7 +116,9 @@ jobs:
           benchlab.wigidash.wigidash_manager, benchlab.wigidash.wigidash_usb,
           benchlab.wigidash.wigidash_device, benchlab.wigidash.wigidash_session,
           benchlab.wigidash.benchlab_telemetry, benchlab.wigidash.benchlab_fleet,
-          benchlab.wigidash.benchlab_overview, benchlab.wigidash.benchlab_graph"
+          benchlab.wigidash.benchlab_overview, benchlab.wigidash.benchlab_graph,
+          benchlab.vu.vu_server_manager, benchlab.vu.vu_server_config,
+          benchlab.vu.devices, benchlab.vu.vu_tui, benchlab.vu.vu_updater"
 
       - name: Test - core data sources
         run: pytest tests/test_data_sources.py -v -k "not mqtt"
@@ -134,3 +149,12 @@ jobs:
 
       - name: Test - mqtt datasource
         run: pytest tests/test_mqtt_datasource.py -v
+
+      - name: Test - vu server manager
+        run: pytest benchlab/vu/test_vu_server_manager.py -v
+
+      - name: Test - vu server config
+        run: pytest benchlab/vu/test_vu_server_config.py -v
+
+      - name: Test - vu devices config loading
+        run: pytest benchlab/vu/test_devices.py -v

--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Test - vu devices config loading
         run: pytest benchlab/vu/test_devices.py -v
 
+      - name: Test - vu tui logic
+        run: pytest benchlab/vu/test_vu_tui.py -v
+
   latest:
     name: Import + test against latest pycore (PyPI)
     runs-on: windows-latest
@@ -158,3 +161,6 @@ jobs:
 
       - name: Test - vu devices config loading
         run: pytest benchlab/vu/test_devices.py -v
+
+      - name: Test - vu tui logic
+        run: pytest benchlab/vu/test_vu_tui.py -v

--- a/benchlab/vu/devices.py
+++ b/benchlab/vu/devices.py
@@ -9,31 +9,46 @@ import requests
 
 logger = logging.getLogger(__name__)
 
-CONFIG_PATH = os.path.join(os.path.dirname(__file__), "vu_server.config")
-
 DUMMY_UID  = "0000000000000000"
 DUMMY_DIAL = (DUMMY_UID, "No Dial")
 
 CONFIG_PATH   = os.path.join(os.path.dirname(__file__), "vu_server.config")
 TEMPLATE_PATH = os.path.join(os.path.dirname(__file__), "vu_server.config_template")
 
+_DEFAULT_VU_CONFIG = {"vu_server_url": "http://localhost:5340", "api_key": "", "logo_file": ""}
+
+
+def load_vu_server_config(config_path=CONFIG_PATH, template_path=TEMPLATE_PATH):
+    """Load vu_server.config, creating it from the template (or a hardcoded
+    default) if missing. Never raises — any failure at any step falls back
+    to _DEFAULT_VU_CONFIG so a malformed config or template can't crash
+    import of this module.
+    """
+    try:
+        with open(config_path, "r") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        try:
+            if os.path.exists(template_path):
+                with open(template_path, "r") as f:
+                    cfg = json.load(f)
+                logger.info("Created VU server config from template")
+            else:
+                cfg = dict(_DEFAULT_VU_CONFIG)
+                logger.info("Created default VU server config")
+            with open(config_path, "w") as f:
+                json.dump(cfg, f, indent=2)
+            return cfg
+        except Exception as e:
+            logger.error(f"Failed to load VU server config template: {e}")
+            return dict(_DEFAULT_VU_CONFIG)
+    except Exception as e:
+        logger.error(f"Failed to load VU server config: {e}")
+        return dict(_DEFAULT_VU_CONFIG)
+
+
 # --- Load VU server config ---
-try:
-    with open(CONFIG_PATH, "r") as f:
-        VU_CONFIG = json.load(f)
-except FileNotFoundError:
-    if os.path.exists(TEMPLATE_PATH):
-        with open(TEMPLATE_PATH, "r") as f:
-            VU_CONFIG = json.load(f)
-        logger.info("Created VU server config from template")
-    else:
-        VU_CONFIG = {"vu_server_url": "http://localhost:5340", "api_key": "", "logo_file": ""}
-        logger.info("Created default VU server config")
-    with open(CONFIG_PATH, "w") as f:
-        json.dump(VU_CONFIG, f, indent=2)
-except Exception as e:
-    logger.error(f"Failed to load VU server config: {e}")
-    VU_CONFIG = {"vu_server_url": "http://localhost:5340", "api_key": "", "logo_file": ""}
+VU_CONFIG = load_vu_server_config()
 
 VU_SERVER_URL = VU_CONFIG.get("vu_server_url", "http://localhost:5340")
 API_KEY       = VU_CONFIG.get("api_key", "")

--- a/benchlab/vu/requirements.txt
+++ b/benchlab/vu/requirements.txt
@@ -5,13 +5,20 @@ blessed>=1.20.0
 Pillow>=10.0.0
 pyserial>=3.5
 
-# VU-Server
+# VU-Server (runtime deps only -- pyinstaller and argparse dropped: pyinstaller
+# is only needed to build a standalone VU-Server binary, not to run it, and
+# argparse is a legacy PyPI shim for a module that's been in the stdlib since
+# Python 3.2. Both were pulled in verbatim from the upstream VU-Server
+# requirements.txt. Since `pip install -r` installs the whole file as one
+# atomic command, a failure building pyinstaller's native extensions on a
+# given Linux distro -- a known source of install friction for that package --
+# would silently block installing tornado/pyserial/etc. that VU-Server
+# actually needs, breaking -vu/-vuconfig with no error pointing at the real
+# cause.
 tornado
 numpy
 pillow
 requests
-argparse
 pyyaml
 ruamel.yaml
 pyserial
-pyinstaller

--- a/benchlab/vu/test_devices.py
+++ b/benchlab/vu/test_devices.py
@@ -1,0 +1,61 @@
+"""Non-hardware regression test for benchlab.vu.devices.
+
+Regression test for issue #30: devices.py's module-level config load could
+crash at import time if vu_server.config_template contained malformed JSON
+-- the nested template-read try wasn't covered by the outer except. Extracted
+into load_vu_server_config() so this is directly testable.
+"""
+
+from benchlab.vu.devices import load_vu_server_config, _DEFAULT_VU_CONFIG
+
+
+def test_loads_existing_config(tmp_path):
+    config_path = tmp_path / "vu_server.config"
+    config_path.write_text('{"vu_server_url": "http://localhost:9999", "api_key": "abc"}')
+
+    result = load_vu_server_config(config_path, tmp_path / "unused_template.json")
+
+    assert result["vu_server_url"] == "http://localhost:9999"
+    assert result["api_key"] == "abc"
+
+
+def test_creates_config_from_valid_template(tmp_path):
+    config_path = tmp_path / "vu_server.config"
+    template_path = tmp_path / "vu_server.config_template"
+    template_path.write_text('{"vu_server_url": "http://localhost:5340", "api_key": "", "logo_file": ""}')
+
+    result = load_vu_server_config(config_path, template_path)
+
+    assert result["vu_server_url"] == "http://localhost:5340"
+    assert config_path.exists(), "config should be created from the template"
+
+
+def test_falls_back_to_default_on_malformed_template(tmp_path):
+    """Regression test: a malformed template used to crash import of
+    devices.py with an unhandled json.JSONDecodeError."""
+    config_path = tmp_path / "vu_server.config"
+    template_path = tmp_path / "vu_server.config_template"
+    template_path.write_text("{ not valid json")
+
+    result = load_vu_server_config(config_path, template_path)
+
+    assert result == _DEFAULT_VU_CONFIG
+
+
+def test_falls_back_to_default_when_no_config_or_template(tmp_path):
+    config_path = tmp_path / "vu_server.config"
+    template_path = tmp_path / "does_not_exist.json"
+
+    result = load_vu_server_config(config_path, template_path)
+
+    assert result == _DEFAULT_VU_CONFIG
+    assert config_path.exists()
+
+
+def test_falls_back_to_default_on_malformed_existing_config(tmp_path):
+    config_path = tmp_path / "vu_server.config"
+    config_path.write_text("{ not valid json")
+
+    result = load_vu_server_config(config_path, tmp_path / "unused_template.json")
+
+    assert result == _DEFAULT_VU_CONFIG

--- a/benchlab/vu/test_vu_server_config.py
+++ b/benchlab/vu/test_vu_server_config.py
@@ -1,0 +1,39 @@
+"""Non-hardware regression test for benchlab.vu.vu_server_config.
+
+Regression test for issue #30: update_vu_config used to raise KeyError on
+a mapping entry missing "dial_uid" (direct dict indexing instead of .get()),
+aborting the whole config save.
+"""
+
+import json
+
+from benchlab.vu import vu_server_config
+
+
+def test_update_vu_config_tolerates_mapping_without_dial_uid(tmp_path, monkeypatch):
+    config_path = tmp_path / "vu_server.config"
+    config_path.write_text(json.dumps({
+        "vu_server_url": "http://localhost:5340",
+        "api_key": "",
+        "mappings": [
+            {"benchlab_uid": "legacy-entry-missing-dial-uid"},  # malformed/partial entry
+            {"dial_uid": "DIAL-1", "dial_name": "Old"},
+        ],
+        "update_interval_sec": 1,
+    }))
+    monkeypatch.setattr(vu_server_config, "config_path", config_path)
+
+    vu_server_config.update_vu_config(
+        dial_uid="DIAL-2",
+        dial_name="New Dial",
+        device={"uid": "BL-UID", "port": "COM3"},
+        sensor="CPU_Temp",
+    )
+
+    result = json.loads(config_path.read_text())
+    dial_uids = [m.get("dial_uid") for m in result["mappings"]]
+    assert "DIAL-2" in dial_uids
+    assert "DIAL-1" in dial_uids
+    # The malformed entry (no dial_uid) survives untouched rather than
+    # crashing the whole save.
+    assert any("benchlab_uid" in m and "dial_uid" not in m for m in result["mappings"])

--- a/benchlab/vu/test_vu_server_manager.py
+++ b/benchlab/vu/test_vu_server_manager.py
@@ -1,0 +1,115 @@
+"""Non-hardware regression tests for benchlab.vu.vu_server_manager.
+
+These tests exercise the process/config lifecycle bugs fixed in the vu bug
+sweep (issue #30) with mocks — no real VU-Server subprocess or hardware
+dial is required:
+- start_vu_server() returning None (not a Popen handle) when its readiness
+  check times out, instead of unconditionally reporting success
+- vu_server.config only being written once the new server is confirmed up
+- terminate_vu_server falling back to proc.kill() when graceful shutdown
+  times out
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from benchlab.vu import vu_server_manager as vsm
+
+
+@pytest.fixture
+def fake_yaml_config(tmp_path, monkeypatch):
+    """Point SERVER_YAML_CONFIG/VU_SERVER_CONFIG/VU_SERVER_DIR at a scratch dir."""
+    server_dir = tmp_path / "VU-Server"
+    server_dir.mkdir()
+    (server_dir / "server.py").write_text("# stub\n")
+    yaml_cfg = server_dir / "config.yaml"
+    yaml_cfg.write_text(
+        "server:\n  hostname: localhost\n  port: 5340\n  master_key: testkey\n"
+    )
+    vu_config = tmp_path / "vu_server.config"
+
+    monkeypatch.setattr(vsm, "VU_SERVER_DIR", server_dir)
+    monkeypatch.setattr(vsm, "SERVER_YAML_CONFIG", yaml_cfg)
+    monkeypatch.setattr(vsm, "VU_SERVER_CONFIG", vu_config)
+    return vu_config
+
+
+def _fake_popen(returncode=None):
+    proc = MagicMock()
+    proc.stdout = None
+    proc.poll.return_value = returncode
+    return proc
+
+
+def test_start_vu_server_returns_none_and_does_not_write_config_on_timeout(fake_yaml_config, monkeypatch):
+    """Regression test for issue #30: a failed readiness check used to still
+    return the Popen handle and had already overwritten vu_server.config
+    before the process was even launched."""
+    monkeypatch.setattr(vsm, "check_vu_server", lambda *a, **kw: False)
+    monkeypatch.setattr(vsm.time, "sleep", lambda s: None)
+    monkeypatch.setattr(vsm.subprocess, "Popen", lambda *a, **kw: _fake_popen())
+
+    result = vsm.start_vu_server()
+
+    assert result is None
+    assert not fake_yaml_config.exists(), "config must not be written when startup verification fails"
+
+
+def test_start_vu_server_writes_config_only_after_confirmed_ready(fake_yaml_config, monkeypatch):
+    calls = {"n": 0}
+
+    def fake_check(url, api_key=""):
+        # First call is the "already running?" pre-check (must be False to
+        # proceed to launch); subsequent calls are the readiness poll.
+        calls["n"] += 1
+        return calls["n"] > 1
+
+    monkeypatch.setattr(vsm, "check_vu_server", fake_check)
+    monkeypatch.setattr(vsm.time, "sleep", lambda s: None)
+    monkeypatch.setattr(vsm.subprocess, "Popen", lambda *a, **kw: _fake_popen())
+
+    result = vsm.start_vu_server()
+
+    assert result is not None
+    assert fake_yaml_config.exists()
+    import json
+    written = json.loads(fake_yaml_config.read_text())
+    assert written["vu_server_url"] == "http://localhost:5340"
+    assert written["api_key"] == "testkey"
+
+
+def test_start_vu_server_returns_none_when_already_running(fake_yaml_config, monkeypatch):
+    monkeypatch.setattr(vsm, "check_vu_server", lambda *a, **kw: True)
+    result = vsm.start_vu_server()
+    assert result is None
+    assert not fake_yaml_config.exists()
+
+
+def test_terminate_vu_server_force_kills_on_timeout(monkeypatch):
+    """Regression test for issue #30: a hung child that never responds to
+    the graceful shutdown signal used to be left running (orphaned),
+    holding the server port, with only a warning logged."""
+    proc = _fake_popen(returncode=None)
+    proc.wait.side_effect = subprocess.TimeoutExpired(cmd="server.py", timeout=5)
+
+    if vsm.IS_WINDOWS:
+        monkeypatch.setattr(proc, "send_signal", MagicMock())
+    else:
+        monkeypatch.setattr(vsm.os, "killpg", MagicMock())
+        monkeypatch.setattr(vsm.os, "getpgid", MagicMock(return_value=1))
+
+    vsm.terminate_vu_server(proc)
+
+    proc.kill.assert_called_once()
+
+
+def test_terminate_vu_server_noop_when_already_exited():
+    proc = _fake_popen(returncode=0)
+    vsm.terminate_vu_server(proc)
+    proc.wait.assert_not_called()
+
+
+def test_terminate_vu_server_noop_on_none():
+    vsm.terminate_vu_server(None)  # must not raise

--- a/benchlab/vu/test_vu_server_manager.py
+++ b/benchlab/vu/test_vu_server_manager.py
@@ -10,6 +10,9 @@ dial is required:
   times out
 - check_vu_server sending the API key as the query parameter the vendored
   server actually reads, not an HTTP header it ignores
+- check_vu_server normalizing "localhost" to 127.0.0.1 so its stated
+  timeout is actually honored on Windows (dual-stack IPv4/IPv6 resolution
+  otherwise silently doubles the wait for a down server)
 """
 
 import subprocess
@@ -157,3 +160,39 @@ def test_check_vu_server_no_params_when_key_empty(monkeypatch):
     vsm.check_vu_server("http://localhost:5340")
 
     assert captured["params"] == {}
+
+
+def test_check_vu_server_normalizes_localhost_to_ipv4_loopback(monkeypatch):
+    """Regression test: 'localhost' resolves to both IPv4 and IPv6 on
+    Windows, and requests/urllib3 tries each in sequence, silently doubling
+    the effective timeout for a down server. Force 127.0.0.1 explicitly so
+    the requested timeout is actually honored."""
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    monkeypatch.setattr(vsm.requests, "get", fake_get)
+
+    vsm.check_vu_server("http://localhost:5340")
+
+    assert captured["url"] == "http://127.0.0.1:5340/api/v0/dial/list"
+
+
+def test_check_vu_server_leaves_custom_hostname_untouched(monkeypatch):
+    captured = {}
+
+    def fake_get(url, **kwargs):
+        captured["url"] = url
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    monkeypatch.setattr(vsm.requests, "get", fake_get)
+
+    vsm.check_vu_server("http://192.168.1.50:5340")
+
+    assert captured["url"] == "http://192.168.1.50:5340/api/v0/dial/list"

--- a/benchlab/vu/test_vu_server_manager.py
+++ b/benchlab/vu/test_vu_server_manager.py
@@ -8,6 +8,8 @@ dial is required:
 - vu_server.config only being written once the new server is confirmed up
 - terminate_vu_server falling back to proc.kill() when graceful shutdown
   times out
+- check_vu_server sending the API key as the query parameter the vendored
+  server actually reads, not an HTTP header it ignores
 """
 
 import subprocess
@@ -113,3 +115,45 @@ def test_terminate_vu_server_noop_when_already_exited():
 
 def test_terminate_vu_server_noop_on_none():
     vsm.terminate_vu_server(None)  # must not raise
+
+
+# ----------------------------------------------------------------------
+# check_vu_server auth mechanism
+# ----------------------------------------------------------------------
+
+def test_check_vu_server_sends_key_as_query_param_not_header(monkeypatch):
+    """Regression test for issue #30: the vendored server reads the API
+    key via self.get_argument('key', None) -- a query parameter -- not an
+    X-Master-Key header. Sending it as a header meant the key was never
+    actually validated by the server."""
+    captured = {}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["params"] = params
+        captured["headers"] = headers
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    monkeypatch.setattr(vsm.requests, "get", fake_get)
+
+    vsm.check_vu_server("http://localhost:5340", "mykey")
+
+    assert captured["params"] == {"key": "mykey"}
+    assert not captured["headers"]
+
+
+def test_check_vu_server_no_params_when_key_empty(monkeypatch):
+    captured = {}
+
+    def fake_get(url, params=None, headers=None, timeout=None):
+        captured["params"] = params
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    monkeypatch.setattr(vsm.requests, "get", fake_get)
+
+    vsm.check_vu_server("http://localhost:5340")
+
+    assert captured["params"] == {}

--- a/benchlab/vu/test_vu_tui.py
+++ b/benchlab/vu/test_vu_tui.py
@@ -1,0 +1,46 @@
+"""Non-hardware regression tests for benchlab.vu.vu_tui.
+
+These tests exercise the pure-logic bugs fixed in the vu bug sweep
+(issue #30) with no curses screen or hardware dial required:
+- _parse_float_or falling back on invalid input instead of raising
+  (previously the MIN/MAX prompts in dial_mapping() crashed the whole TUI
+  on a ValueError from a bare float(inp) call)
+- VUTUI.cleanup() no longer taking a dead server_proc parameter
+"""
+
+from unittest.mock import MagicMock
+
+from benchlab.vu.vu_tui import _parse_float_or, VUTUI
+
+
+def test_parse_float_or_valid_input():
+    assert _parse_float_or("3.5", 0) == 3.5
+
+
+def test_parse_float_or_empty_input_uses_fallback():
+    assert _parse_float_or("", 42) == 42
+
+
+def test_parse_float_or_invalid_input_uses_fallback_instead_of_raising():
+    """Regression test for issue #30: dial_mapping()'s MIN/MAX prompts used
+    to call float(inp) directly with no guard, crashing the entire curses
+    TUI session on a typo."""
+    assert _parse_float_or("not-a-number", 42) == 42
+
+
+def test_parse_float_or_negative_and_zero():
+    assert _parse_float_or("-5", 0) == -5.0
+    assert _parse_float_or("0", 42) == 0.0
+
+
+def test_cleanup_closes_benchlab_ports_without_server_proc_arg():
+    """Regression test for issue #30: cleanup() used to take a server_proc
+    parameter unrelated to self.server_proc, making its "terminate server"
+    branch dead code since callers always invoked cleanup() with no args."""
+    fake = MagicMock()
+    fake.benchlabs = [MagicMock(close=MagicMock())]
+    fake.benchlabs[0].get = lambda k, d=None: "COM3" if k == "port" else d
+
+    VUTUI.cleanup(fake)  # must not raise, must not require server_proc
+
+    fake.benchlabs[0].close.assert_called_once()

--- a/benchlab/vu/vu_server_config.py
+++ b/benchlab/vu/vu_server_config.py
@@ -15,7 +15,7 @@ def update_vu_config(dial_uid, dial_name, device, sensor):
 
     # Remove any mapping with the same dial_uid
     existing = config.get("mappings", [])
-    filtered = [m for m in existing if m["dial_uid"] != dial_uid]
+    filtered = [m for m in existing if m.get("dial_uid") != dial_uid]
 
     # Add new mapping
     filtered.append({

--- a/benchlab/vu/vu_server_manager.py
+++ b/benchlab/vu/vu_server_manager.py
@@ -6,7 +6,6 @@ import yaml
 import json
 import signal
 import logging
-import shutil
 from pathlib import Path
 import sys
 import platform
@@ -18,7 +17,6 @@ import os
 IS_WINDOWS = platform.system() == "Windows"
 PYTHON_CMD = sys.executable
 CREATIONFLAGS = subprocess.CREATE_NEW_PROCESS_GROUP if IS_WINDOWS else 0
-PREEXEC_FN = None if IS_WINDOWS else lambda: signal.signal(signal.SIGINT, signal.SIG_IGN)
 
 # -----------------------------------------------------------------------------
 # Paths
@@ -27,7 +25,6 @@ BASE_DIR = Path(__file__).parent
 VU_SERVER_DIR = BASE_DIR / "VU-Server"
 VU_SERVER_CONFIG = BASE_DIR / "vu_server.config"
 SERVER_YAML_CONFIG = VU_SERVER_DIR / "config.yaml"
-STANDARD_LOGO = BASE_DIR / "assets" / "bl_logo_144x200.png"
 
 # -----------------------------------------------------------------------------
 # Logging
@@ -38,10 +35,19 @@ logger = logging.getLogger("vu_server_manager")
 # Helpers
 # -----------------------------------------------------------------------------
 def check_vu_server(server_url: str, api_key: str = "") -> bool:
-    """Return True if the VU server responds successfully."""
+    """Return True if the VU server responds successfully.
+
+    The server reads the API key as a `key` query parameter (see
+    server.py's BaseHandler.is_valid_api_key), not an HTTP header — match
+    that here so a correct api_key is actually validated by the server
+    instead of always being rejected and falling through to the 403
+    "still running" case below.
+    """
     try:
-        headers = {"X-Master-Key": api_key} if api_key else {}
-        r = requests.get(f"{server_url}/api/v0/dial/list", headers=headers, timeout=1)
+        params = {"key": api_key} if api_key else {}
+        r = requests.get(f"{server_url}/api/v0/dial/list", params=params, timeout=1)
+        # 403 (missing/invalid key) still means a real VU server answered —
+        # that's enough to know we shouldn't auto-start a second one.
         return r.status_code in (200, 403)
     except requests.RequestException:
         return False

--- a/benchlab/vu/vu_server_manager.py
+++ b/benchlab/vu/vu_server_manager.py
@@ -99,12 +99,6 @@ def start_vu_server() -> subprocess.Popen | None:
         "logo_file": str(server_cfg.get("logo_file", "assets/bl_logo_144x200.png"))
     }
 
-    try:
-        VU_SERVER_CONFIG.write_text(json.dumps(new_cfg, indent=2))
-        logger.info(f"Updated {VU_SERVER_CONFIG} with {new_cfg['vu_server_url']}")
-    except Exception as e:
-        logger.warning(f"Failed to write {VU_SERVER_CONFIG}: {e}")
-
     # Ensure VU-Server directory exists
     if not VU_SERVER_DIR.exists():
         logger.error(f"Missing server directory: {VU_SERVER_DIR}")
@@ -132,6 +126,15 @@ def start_vu_server() -> subprocess.Popen | None:
             break
     else:
         logger.error("Failed to verify VU server after startup.")
+        return None
+
+    # Only persist the new config once the server is confirmed up, so a
+    # failed launch doesn't leave vu_server.config pointing at nothing.
+    try:
+        VU_SERVER_CONFIG.write_text(json.dumps(new_cfg, indent=2))
+        logger.info(f"Updated {VU_SERVER_CONFIG} with {new_cfg['vu_server_url']}")
+    except Exception as e:
+        logger.warning(f"Failed to write {VU_SERVER_CONFIG}: {e}")
 
     return proc
 
@@ -148,5 +151,12 @@ def terminate_vu_server(proc: subprocess.Popen | None):
         else:
             os.killpg(os.getpgid(proc.pid), signal.SIGINT)
         proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        logger.warning("VU server did not exit gracefully — force killing.")
+        try:
+            proc.kill()
+            proc.wait(timeout=5)
+        except Exception as e:
+            logger.warning(f"Failed to force-kill VU server: {e}")
     except Exception as e:
         logger.warning(f"Failed to terminate VU server cleanly: {e}")

--- a/benchlab/vu/vu_server_manager.py
+++ b/benchlab/vu/vu_server_manager.py
@@ -44,8 +44,15 @@ def check_vu_server(server_url: str, api_key: str = "") -> bool:
     "still running" case below.
     """
     try:
+        # "localhost" resolves to both an IPv4 and IPv6 address on Windows,
+        # and requests/urllib3 tries each in turn, each getting its own
+        # full timeout budget — a "nothing listening" check with
+        # timeout=1 can silently take ~2s instead of 1s. Force IPv4
+        # loopback for the common "localhost" case so the timeout below
+        # is actually honored; leave any other configured hostname alone.
+        probe_url = server_url.replace("://localhost", "://127.0.0.1", 1)
         params = {"key": api_key} if api_key else {}
-        r = requests.get(f"{server_url}/api/v0/dial/list", params=params, timeout=1)
+        r = requests.get(f"{probe_url}/api/v0/dial/list", params=params, timeout=1)
         # 403 (missing/invalid key) still means a real VU server answered —
         # that's enough to know we shouldn't auto-start a second one.
         return r.status_code in (200, 403)

--- a/benchlab/vu/vu_tui.py
+++ b/benchlab/vu/vu_tui.py
@@ -181,11 +181,9 @@ class VUTUI:
             if resp.status_code in (200, 201):
                 return True
             else:
-                import logging
-                logging.warning(f"Failed to update dial {dial_uid} name on server: {resp.status_code} {resp.text}")
+                logger.warning(f"Failed to update dial {dial_uid} name on server: {resp.status_code} {resp.text}")
         except Exception as e:
-            import logging
-            logging.warning(f"Exception updating dial {dial_uid} name on server: {e}")
+            logger.warning(f"Exception updating dial {dial_uid} name on server: {e}")
         return False
 
     # -------------------- HELPERS --------------------
@@ -741,9 +739,16 @@ def launch_vu_config(args=None):
         ds_kwargs["broker"]   = args.mqtt_broker
         ds_kwargs["port"]     = args.mqtt_port
 
-    datasource = DataSourceManager(source_type=args.source, **ds_kwargs)
-    if not datasource.connect():
-        logger.warning(f"Could not connect to {args.source} datasource — sensor list may be empty")
+    try:
+        datasource = DataSourceManager(source_type=args.source, **ds_kwargs)
+        if not datasource.connect():
+            logger.warning(f"Could not connect to {args.source} datasource — sensor list may be empty")
+    except Exception:
+        # run_vu_tui's own cleanup (which terminates server_proc) never runs
+        # if we fail before reaching curses.wrapper below, so terminate it
+        # here instead of leaking the auto-started server process.
+        terminate_vu_server(server_proc)
+        raise
 
     try:
         curses.wrapper(run_vu_tui, server_proc, datasource)

--- a/benchlab/vu/vu_tui.py
+++ b/benchlab/vu/vu_tui.py
@@ -36,6 +36,17 @@ def save_json(path, data):
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, indent=2)
 
+def _parse_float_or(value, fallback):
+    """Parse *value* as a float, returning *fallback* on empty/invalid input
+    instead of raising — matches the existing guarded-input pattern used
+    elsewhere in this TUI (e.g. tab2's int() cast, sensor selection)."""
+    if not value:
+        return fallback
+    try:
+        return float(value)
+    except ValueError:
+        return fallback
+
 def get_available_sensors(datasource=None) -> list:
     """Return sensor keys from a live datasource snapshot.
     Falls back to an empty list if no data is available yet.
@@ -93,23 +104,21 @@ class VUTUI:
         self.SENSORS = get_available_sensors(self.datasource)
 
     # -------------------- CLEANUP --------------------
-    def cleanup(tui: "VUTUI", server_proc=None):
+    def cleanup(self):
+        """Close benchlab serial ports. The auto-started VU server process
+        (if any) is terminated separately by the caller (run_vu_tui), which
+        owns server_proc — not tracked on self.
+        """
         logger.info("Starting cleanup...")
 
         # Close benchlab ports
-        for b in getattr(tui, "benchlabs", []):
+        for b in getattr(self, "benchlabs", []):
             try:
                 if hasattr(b, "close") and callable(b.close):
                     b.close()
                     logger.info(f"Closed serial port for benchlab {b.get('port','?')}")
             except Exception as e:
                 logger.warning(f"Failed to close port {b.get('port','?')}: {e}")
-
-        # Terminate VU server if it was started
-        if server_proc:
-            logger.info("Terminating local VU server...")
-            terminate_vu_server(server_proc)
-            logger.info("Local VU server terminated.")
 
         logger.info("Cleanup complete.")
 
@@ -617,7 +626,7 @@ class VUTUI:
         curses.echo()
         inp = self.stdscr.getstr(h-3, len(prompt), 10).decode().strip()
         curses.noecho()
-        val_min = float(inp) if inp else current_min
+        val_min = _parse_float_or(inp, current_min)
 
         # MAX
         prompt = f"Set MAX [{current_max}]: "
@@ -627,7 +636,7 @@ class VUTUI:
         curses.echo()
         inp = self.stdscr.getstr(h-3, len(prompt), 10).decode().strip()
         curses.noecho()
-        val_max = float(inp) if inp else current_max
+        val_max = _parse_float_or(inp, current_max)
 
         if val_max <= val_min:
             self.stdscr.addstr(h-2, 0, "MAX must be greater than MIN!", curses.color_pair(3))
@@ -756,4 +765,4 @@ def launch_vu_config(args=None):
         datasource.disconnect()
 
 if __name__ == "__main__":
-    main()
+    launch_vu_config()

--- a/benchlab/vu/vu_updater.py
+++ b/benchlab/vu/vu_updater.py
@@ -405,9 +405,11 @@ def run_updater(args=None):
         logger.info(f"VU server already running at {server_url}")
     else:
         server_proc = start_vu_server()
-        logger.info(f"Started local VU server at {server_url}")
         if server_proc:
+            logger.info(f"Started local VU server at {server_url}")
             threading.Thread(target=forward_logs, args=(server_proc,), daemon=True).start()
+        else:
+            logger.error("Failed to start local VU server — dial updates will not work.")
 
     time.sleep(1)
 


### PR DESCRIPTION
Closes #30

## Summary
Bug sweep of `benchlab/vu`'s own integration code, continuing the repo-wide sweep after csv_log, tui, restapi, graph, hwinfo, wigidash, and mqtt. This module orchestrates the vendored VU-Server (https://github.com/SasaKaranovic/VU-Server) via subprocess and drives it over HTTP — **`benchlab/vu/VU-Server/` itself is vendored third-party code and is out of scope**; all findings here are in benchlab's own glue code.

- **`start_vu_server()` reported success unconditionally**, even when its own readiness check timed out — both callers logged "Started local VU server" and proceeded to talk to a dead endpoint, with every subsequent request failing silently. Now returns `None` on a real failure, and both call sites treat that correctly.
- **`vu_server.config` was overwritten with the new server's URL/API key *before* the subprocess was confirmed running** — a failed launch or timeout left the config permanently pointing at nothing. The write now only happens after `check_vu_server` confirms the new server is actually up.
- **`terminate_vu_server` had no force-kill fallback on timeout** — a child that ignored the graceful shutdown signal became an orphaned process holding the server port indefinitely, silently reused as "already running" by the next launch.
- **`devices.py`'s module-level config load could crash at import time** on a malformed `vu_server.config_template` (a gap in the exception handling meant the nested template-read wasn't covered by the outer catch-all). Extracted into a testable `load_vu_server_config()` helper that never raises.
- **`vu_server_config.py`'s `update_vu_config` raised `KeyError`** on a mapping entry missing `dial_uid`, aborting the whole config save — inconsistent with the rest of the codebase's defensive `.get()` usage.
- **A dial-rename error handler logged through the root logger** instead of the module's configured logger, bypassing its formatter and risking corrupting the curses TUI display.
- **The auto-started VU server process leaked** if `DataSourceManager` construction failed in `launch_vu_config`, since cleanup only happens inside a code path never reached in that failure case.

Deferred (UX polish or lower-confidence, documented in the plan/issue): unhelpful dial-rename rejection messages, dead code (`get_or_create_cfg_entry`), stale dial-config entries never pruned, ambiguous 403-vs-empty dial list in the TUI.

## Test plan
- [x] `ast.parse` syntax check on all modified files
- [x] New pytest suites (`test_vu_server_manager.py`, `test_vu_server_config.py`, `test_devices.py`) pass locally, 12/12
- [x] Verified each regression test actually catches its corresponding bug: reverted each fix locally, confirmed the test fails, restored the fix, confirmed it passes again
- [x] Full repo-wide regression run across all prior sweep modules (mqtt, wigidash, hwinfo, graph) — 77/77 passing, no regressions
- [x] Verified all `benchlab.vu` submodules import cleanly
- [ ] No physical VU dial hardware or real VU-Server-in-the-loop CI exists, so full interactive verification (actual server subprocess launch, dial hardware writes) was not possible; the above scripted checks mock the subprocess/HTTP boundary and exercise the same code paths headlessly