### PR TITLE
Fix config bug sweep, add diff-before-apply import UX

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -35,7 +35,8 @@ jobs:
         run: >
           python -c "import benchlab.core, benchlab.core.discovery,
           benchlab.core.datasource, benchlab.core.shared_serial,
-          benchlab.config.config_client, benchlab.restapi.telemetry_api,
+          benchlab.config.config_client, benchlab.config.config_manager,
+          benchlab.config.diff, benchlab.restapi.telemetry_api,
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export,
           benchlab.tui.config, benchlab.tui.tui_core, benchlab.tui.tui_main,
           benchlab.graph.app, benchlab.graph.ui,
@@ -87,6 +88,15 @@ jobs:
 
       - name: Test - vu tui logic
         run: pytest benchlab/vu/test_vu_tui.py -v
+
+      - name: Test - config diff logic
+        run: pytest benchlab/config/test_diff.py -v
+
+      - name: Test - config manager
+        run: pytest benchlab/config/test_config_manager.py -v
+
+      - name: Test - config client (calibration struct selection)
+        run: pytest benchlab/config/test_config_client.py -v
 
   latest:
     name: Import + test against latest pycore (PyPI)
@@ -112,7 +122,8 @@ jobs:
         run: >
           python -c "import benchlab.core, benchlab.core.discovery,
           benchlab.core.datasource, benchlab.core.shared_serial,
-          benchlab.config.config_client, benchlab.restapi.telemetry_api,
+          benchlab.config.config_client, benchlab.config.config_manager,
+          benchlab.config.diff, benchlab.restapi.telemetry_api,
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export,
           benchlab.tui.config, benchlab.tui.tui_core, benchlab.tui.tui_main,
           benchlab.graph.app, benchlab.graph.ui,
@@ -164,3 +175,12 @@ jobs:
 
       - name: Test - vu tui logic
         run: pytest benchlab/vu/test_vu_tui.py -v
+
+      - name: Test - config diff logic
+        run: pytest benchlab/config/test_diff.py -v
+
+      - name: Test - config manager
+        run: pytest benchlab/config/test_config_manager.py -v
+
+      - name: Test - config client (calibration struct selection)
+        run: pytest benchlab/config/test_config_client.py -v

--- a/benchlab/config/README.md
+++ b/benchlab/config/README.md
@@ -73,11 +73,18 @@ python benchlab.py -config --export my_config.json --source named_pipe
 #### Import Configuration
 
 ```bash
-# Import configuration
+# Import configuration - shows a diff of what would actually change on the
+# device (current value -> new value, only changed fields), then asks for
+# confirmation before applying
 python benchlab.py -config --import my_config.json
 
-# Dry-run (validate without applying)
+# Preview changes without applying anything (still connects to the device
+# and reads its current config to compute the diff)
 python benchlab.py -config --import my_config.json --dry-run
+
+# Apply without the confirmation prompt (diff is still printed) - for
+# scripts/automation
+python benchlab.py -config --import my_config.json --yes
 
 # Import via named pipe
 python benchlab.py -config --import my_config.json --source named_pipe
@@ -253,7 +260,7 @@ The tool provides detailed error messages for:
 - Device connection errors
 - Configuration write failures
 
-Use `--dry-run` to validate configuration files without applying changes.
+Use `--dry-run` to preview exactly what would change on the device (connects and reads current config to compute a diff) without applying anything. Use `--yes` to skip the confirmation prompt while still showing the diff, for scripted/automated use.
 
 ## Troubleshooting
 
@@ -310,9 +317,8 @@ manager.import_config('input.json', dry_run=False)
 
 ## See Also
 
-- [AI_GUIDE_JSON_CONFIG_TOOL.md](AI_GUIDE_JSON_CONFIG_TOOL.md) - Detailed implementation guide
-- [pycore_README.md](pycore_README.md) - PyCore library documentation
 - [BENCHLAB PyTools Documentation](../../README.md) - Main PyTools documentation
+- [benchlab-pycore](https://github.com/BenchLab-io/benchlab-pycore) - PyCore library used for direct serial configuration I/O
 
 ## License
 

--- a/benchlab/config/config_client.py
+++ b/benchlab/config/config_client.py
@@ -12,6 +12,69 @@ from typing import Optional, Dict, Any
 
 logger = logging.getLogger("benchlab.config.client")
 
+DISCOVERY_PIPE_NAME = "BenchlabDiscovery"
+
+
+def query_named_pipe(pipe_name: str, command: str, payload=None, timeout_ms: int = 5000):
+    """Send a single command to a named pipe and return the parsed JSON response.
+
+    Standalone helper (not tied to a device-scoped NamedPipeConfigClient) so
+    the BenchlabDiscovery pipe -- which isn't associated with any one device
+    -- can be queried the same way, e.g. for ListDevices. Mirrors
+    NamedPipeConfigClient._send_command's open/write/read/close sequence.
+
+    Returns the parsed JSON response (dict or list), or None on failure.
+    """
+    import win32file
+    import win32pipe
+    import pywintypes
+
+    path = f"\\\\.\\pipe\\{pipe_name}"
+    handle = None
+    try:
+        win32pipe.WaitNamedPipe(path, timeout_ms)
+        handle = win32file.CreateFile(
+            path,
+            win32file.GENERIC_READ | win32file.GENERIC_WRITE,
+            0, None,
+            win32file.OPEN_EXISTING,
+            0, None
+        )
+
+        win32file.WriteFile(handle, (command + "\n").encode("utf-8"))
+        if payload is not None:
+            if isinstance(payload, str):
+                win32file.WriteFile(handle, (payload + "\n").encode("utf-8"))
+            else:
+                win32file.WriteFile(handle, (json.dumps(payload) + "\n").encode("utf-8"))
+
+        chunks = []
+        while True:
+            try:
+                _, data = win32file.ReadFile(handle, 4096)
+                if not data:
+                    break
+                chunks.append(data)
+            except pywintypes.error as e:
+                if e.winerror == 109:  # Pipe closed
+                    break
+                raise
+
+        response_text = b"".join(chunks).decode("utf-8", errors="replace").strip()
+        if not response_text:
+            return None
+        return json.loads(response_text)
+
+    except (pywintypes.error, json.JSONDecodeError) as e:
+        logger.error(f"Pipe command failed on {pipe_name}: {e}")
+        return None
+    finally:
+        if handle is not None:
+            try:
+                win32file.CloseHandle(handle)
+            except Exception:
+                pass
+
 
 class ConfigClient(ABC):
     """Abstract base class for device configuration clients."""
@@ -285,15 +348,23 @@ class DirectConfigClient(ConfigClient):
     
     def write_calibration(self, calibration: Dict[str, Any]) -> bool:
         """Write calibration data."""
-        from benchlab_pycore.core import write_calibration, CalibrationStruct
-        
+        from benchlab_pycore.core import (
+            write_calibration, CalibrationStruct, CalibrationStructBL2, BENCHLAB_BL2_PRODUCT_ID,
+        )
+
+        # Select the struct type matching the connected device's variant --
+        # BL2 has 8 temp sensors vs Original's 4, so the struct sizes and
+        # array lengths differ. Mirrors benchlab_pycore.core.read_calibration's
+        # own product_id -> struct_type selection.
+        struct_type = CalibrationStructBL2 if self.product_id == BENCHLAB_BL2_PRODUCT_ID else CalibrationStruct
+
         # Reconstruct calibration struct from dict
         try:
-            cal = self._dict_to_struct(calibration, CalibrationStruct)
+            cal = self._dict_to_struct(calibration, struct_type)
         except Exception as e:
             logger.error(f"Failed to reconstruct calibration struct: {e}")
             return False
-        
+
         return write_calibration(self.ser, calibration=cal, product_id=self.product_id)
     
     def save_config(self) -> bool:

--- a/benchlab/config/config_manager.py
+++ b/benchlab/config/config_manager.py
@@ -6,13 +6,19 @@ Orchestrates device discovery, selection, and configuration operations.
 
 import json
 import logging
-import os
 from typing import Optional, Dict, Any, List
 
-from .config_client import create_config_client, ConfigClient
+from .config_client import create_config_client, ConfigClient, query_named_pipe, DISCOVERY_PIPE_NAME
 from .schema import ConfigFile, validate_config_file
+from .diff import compute_diff, format_diff, DiffResult
 
 logger = logging.getLogger("benchlab.config.manager")
+
+
+def _default_confirm(diff: DiffResult, device_label: str) -> bool:
+    """Default confirm_callback for import_config: interactive y/n prompt."""
+    answer = input(f"Apply these changes to {device_label}? (yes/no): ").strip().lower()
+    return answer in ('y', 'yes')
 
 
 class ConfigManager:
@@ -52,37 +58,37 @@ class ConfigManager:
             return []
     
     def _discover_named_pipe(self) -> List[Dict[str, Any]]:
-        """Discover devices via named pipes."""
+        """Discover devices via the BenchlabDiscovery named pipe's ListDevices
+        command -- a single round-trip that returns all devices' info
+        (including the server-confirmed pipeName for each), rather than
+        listing local pipes and querying each device individually.
+        """
         import sys
         if not sys.platform.startswith("win"):
             logger.error("Named pipe discovery only supported on Windows")
             return []
-        
+
         try:
-            pipes = [name for name in os.listdir(r"\\.\pipe\\") 
-                    if name.startswith("BenchlabSensorPipe_")]
-            
-            devices = []
-            for pipe_name in pipes:
-                try:
-                    client = create_config_client('named_pipe', pipe_name)
-                    info = client.get_device_info()
-                    client.close()
-                    
-                    if info:
-                        devices.append({
-                            'pipe': pipe_name,
-                            'guid': info.get('guid'),
-                            'port': info.get('port'),
-                            'productId': info.get('productId'),
-                            'deviceName': info.get('deviceName'),
-                        })
-                except Exception as e:
-                    logger.warning(f"Failed to query pipe {pipe_name}: {e}")
-            
+            result = query_named_pipe(DISCOVERY_PIPE_NAME, "ListDevices")
+            if not isinstance(result, list):
+                logger.warning(f"Unexpected ListDevices response: {result!r}")
+                return []
+
+            devices = [
+                {
+                    'pipe': d.get('pipeName'),
+                    'guid': d.get('guid'),
+                    'port': d.get('port'),
+                    'productId': d.get('productId'),
+                    'deviceName': d.get('deviceName'),
+                }
+                for d in result
+                if d.get('pipeName')
+            ]
+
             logger.info(f"Discovered {len(devices)} device(s) via named pipes")
             return devices
-            
+
         except Exception as e:
             logger.error(f"Failed to discover named pipe devices: {e}")
             return []
@@ -99,14 +105,22 @@ class ConfigManager:
         """
         sel_type = selector.get('type')
         sel_value = selector.get('value')
-        
+
+        if sel_type == 'productId' and self.source == 'direct':
+            logger.warning(
+                "productId selector is not supported for the direct source "
+                "(product ID isn't available from fleet discovery without "
+                "connecting to each device first) — use guid or port instead."
+            )
+            return None
+
         if sel_type == 'any' and devices:
             # Return first available device
             if self.source == 'direct':
                 return devices[0].get('port')
             else:
                 return devices[0].get('pipe')
-        
+
         for device in devices:
             if self.source == 'direct':
                 # Direct serial matching
@@ -114,9 +128,6 @@ class ConfigManager:
                     return device.get('port')
                 elif sel_type == 'guid' and device.get('uid') == sel_value:
                     return device.get('port')
-                elif sel_type == 'productId':
-                    # Need to connect to check product ID
-                    pass
             else:
                 # Named pipe matching
                 if sel_type == 'guid' and device.get('guid') == sel_value:
@@ -125,32 +136,105 @@ class ConfigManager:
                     return device.get('pipe')
                 elif sel_type == 'pipeName' and device.get('pipe') == sel_value:
                     return device.get('pipe')
-        
+
         return None
     
+    def _read_current_state(self, client: ConfigClient) -> Dict[str, Any]:
+        """Read a device's current name/fan/RGB/calibration state.
+
+        Returns a dict shaped like a DeviceConfig (deviceName, fanProfiles,
+        rgbProfiles, calibration), plus a 'readErrors' list describing any
+        section that failed to read. Never raises -- callers (export and the
+        diff-before-apply path) both need read failures to be non-fatal so a
+        flaky calibration read (for example) doesn't block everything else,
+        matching the tolerance export_config already had for calibration.
+        """
+        read_errors: List[str] = []
+
+        try:
+            device_name = client.read_device_name()
+        except Exception as e:
+            logger.warning(f"Could not read device name: {e}")
+            device_name = None
+            read_errors.append(f"device name: {e}")
+
+        # Read fan profiles (all 3 profiles, all 9 fans)
+        fan_profiles = []
+        for profile_id in range(3):
+            fans = []
+            for fan_id in range(9):
+                try:
+                    fan_config = client.read_fan_config(profile_id, fan_id)
+                except Exception as e:
+                    logger.warning(f"Could not read fan config {profile_id}/{fan_id}: {e}")
+                    read_errors.append(f"fan profile {profile_id} fan {fan_id}: {e}")
+                    continue
+                if fan_config:
+                    fan_config['fanId'] = fan_id
+                    fans.append(fan_config)
+
+            if fans:
+                fan_profiles.append({
+                    'profileId': profile_id,
+                    'fans': fans
+                })
+
+        # Read RGB profiles (both profiles)
+        rgb_profiles = []
+        for profile_id in range(2):
+            try:
+                rgb_config = client.read_rgb_config(profile_id)
+            except Exception as e:
+                logger.warning(f"Could not read RGB config {profile_id}: {e}")
+                read_errors.append(f"RGB profile {profile_id}: {e}")
+                continue
+            if rgb_config:
+                rgb_config['profileId'] = profile_id
+                rgb_profiles.append(rgb_config)
+
+        # Read calibration
+        calibration = None
+        try:
+            calibration = client.read_calibration()
+        except Exception as e:
+            logger.warning(f"Could not read calibration: {e}")
+            read_errors.append(f"calibration: {e}")
+
+        return {
+            'deviceName': device_name,
+            'fanProfiles': fan_profiles if fan_profiles else None,
+            'rgbProfiles': rgb_profiles if rgb_profiles else None,
+            'calibration': calibration,
+            'readErrors': read_errors,
+        }
+
     def export_config(self, identifier: str, output_file: str) -> bool:
         """Export device configuration to JSON file.
-        
+
         Args:
             identifier: Device identifier (port or pipe name)
             output_file: Output JSON file path
-            
+
         Returns:
             True if successful
         """
         try:
             client = create_config_client(self.source, identifier)
-            
+        except Exception as e:
+            logger.error(f"Failed to connect: {e}")
+            return False
+
+        try:
             # Read device info
             device_info = client.get_device_info()
             if not device_info:
                 logger.error("Failed to read device info")
                 return False
-            
+
             # Build selector based on available info - prefer UID/GUID over port
             uid = device_info.get('uid')
             guid = device_info.get('guid')
-            
+
             if self.source == 'direct' and uid:
                 selector = {
                     'type': 'guid',
@@ -167,78 +251,65 @@ class ConfigManager:
                     'type': 'port',
                     'value': identifier
                 }
-            
-            # Read device name
-            device_name = client.read_device_name()
-            
-            # Read fan profiles (all 3 profiles, all 9 fans)
-            fan_profiles = []
-            for profile_id in range(3):
-                fans = []
-                for fan_id in range(9):
-                    fan_config = client.read_fan_config(profile_id, fan_id)
-                    if fan_config:
-                        fan_config['fanId'] = fan_id
-                        fans.append(fan_config)
-                
-                if fans:
-                    fan_profiles.append({
-                        'profileId': profile_id,
-                        'fans': fans
-                    })
-            
-            # Read RGB profiles (both profiles)
-            rgb_profiles = []
-            for profile_id in range(2):
-                rgb_config = client.read_rgb_config(profile_id)
-                if rgb_config:
-                    rgb_config['profileId'] = profile_id
-                    rgb_profiles.append(rgb_config)
-            
-            # Read calibration
-            calibration = None
-            try:
-                calibration = client.read_calibration()
-                if calibration:
-                    logger.info("Calibration data exported")
-            except Exception as e:
-                logger.warning(f"Could not read calibration: {e}")
-            
+
+            state = self._read_current_state(client)
+            if state['calibration']:
+                logger.info("Calibration data exported")
+
             # Build config structure
             config = {
                 'version': '1.0',
-                'description': f'Exported from {device_name or identifier}',
+                'description': f'Exported from {state["deviceName"] or identifier}',
                 'devices': [{
                     'selector': selector,
-                    'deviceName': device_name,
-                    'fanProfiles': fan_profiles if fan_profiles else None,
-                    'rgbProfiles': rgb_profiles if rgb_profiles else None,
-                    'calibration': calibration,
+                    'deviceName': state['deviceName'],
+                    'fanProfiles': state['fanProfiles'],
+                    'rgbProfiles': state['rgbProfiles'],
+                    'calibration': state['calibration'],
                     'saveToFlash': False
                 }]
             }
-            
+
             # Write to file
             with open(output_file, 'w') as f:
                 json.dump(config, f, indent=2)
-            
-            client.close()
+
             logger.info(f"Exported configuration to {output_file}")
             return True
-            
+
         except Exception as e:
             logger.error(f"Failed to export config: {e}")
             return False
+        finally:
+            client.close()
     
-    def import_config(self, config_file: str, dry_run: bool = False, save_to_flash: bool = None) -> bool:
+    def import_config(
+        self,
+        config_file: str,
+        dry_run: bool = False,
+        save_to_flash: bool = None,
+        auto_confirm: bool = False,
+        confirm_callback=None,
+    ) -> bool:
         """Import configuration from JSON file.
-        
+
+        Reads each selected device's current state, computes a diff against
+        the desired config, and prints it before applying -- so users see
+        exactly what would change rather than writing blind.
+
         Args:
             config_file: Input JSON file path
-            dry_run: If True, validate only without applying
+            dry_run: If True, show the diff for each device but don't apply
+                     or prompt for confirmation.
             save_to_flash: If True, override saveToFlash in config and save to flash.
                           If False, override and don't save. If None, use config file setting.
-            
+            auto_confirm: If True, skip the confirmation prompt and apply
+                          immediately after showing the diff (for automation).
+            confirm_callback: Called with the rendered diff text; return True
+                          to apply, False to skip this device. Defaults to an
+                          interactive y/n prompt on stdin. Ignored when
+                          auto_confirm=True or dry_run=True.
+
         Returns:
             True if successful
         """
@@ -246,45 +317,76 @@ class ConfigManager:
             # Load and validate config file
             with open(config_file, 'r') as f:
                 config_dict = json.load(f)
-            
+
             config = validate_config_file(config_dict)
             logger.info(f"Loaded config: {config.description}")
             logger.info(f"Version: {config.version}")
             logger.info(f"Devices: {len(config.devices)}")
-            
-            if dry_run:
-                logger.info("DRY RUN - No changes will be applied")
-                return True
-            
+
             # Discover available devices
             devices = self.discover_devices()
             if not devices:
                 logger.error("No devices found")
                 return False
-            
+
+            if confirm_callback is None:
+                confirm_callback = _default_confirm
+
             # Apply configuration to each device
             success_count = 0
             for i, device_config in enumerate(config.devices):
                 logger.info(f"--- Device {i+1}/{len(config.devices)} ---")
-                
+
                 # Select device
                 identifier = self.select_device(device_config.selector.model_dump(), devices)
                 if not identifier:
                     logger.error(f"Device not found matching selector: {device_config.selector}")
                     continue
-                
+
                 logger.info(f"Selected: {identifier}")
-                
+
+                # Read current state and show a diff before applying anything
+                try:
+                    client = create_config_client(self.source, identifier)
+                except Exception as e:
+                    logger.error(f"Failed to connect to {identifier}: {e}")
+                    continue
+                try:
+                    current_state = self._read_current_state(client)
+                finally:
+                    client.close()
+
+                diff = compute_diff(current_state, device_config)
+                device_label = device_config.deviceName or identifier
+                print(format_diff(diff, device_label))
+
+                if diff.is_empty():
+                    logger.info("No changes needed for this device.")
+                    success_count += 1
+                    continue
+
+                if dry_run:
+                    continue
+
+                if not auto_confirm:
+                    if not confirm_callback(diff, device_label):
+                        logger.info("Skipped by user.")
+                        continue
+
                 # Apply configuration
                 if self._apply_device_config(identifier, device_config, save_to_flash):
                     logger.info("Configuration applied successfully")
                     success_count += 1
                 else:
                     logger.error("Configuration failed")
-            
+
+            if dry_run:
+                logger.info("DRY RUN - No changes were applied")
+                return True
+
             logger.info(f"{success_count}/{len(config.devices)} devices configured successfully")
             return success_count == len(config.devices)
-            
+
         except Exception as e:
             logger.error(f"Failed to import config: {e}")
             return False
@@ -302,54 +404,60 @@ class ConfigManager:
         """
         try:
             client = create_config_client(self.source, identifier)
+        except Exception as e:
+            logger.error(f"Failed to connect: {e}")
+            return False
+
+        try:
             success = True
-            
+
             # Set device name
             if device_config.deviceName:
                 if not client.write_device_name(device_config.deviceName):
                     logger.error("Failed to set device name")
                     success = False
-            
+
             # Apply fan profiles
             if device_config.fanProfiles:
                 for profile in device_config.fanProfiles:
                     for fan in profile.fans:
                         fan_dict = fan.model_dump()
                         fan_id = fan_dict.pop('fanId')
-                        
+
                         if not client.write_fan_config(profile.profileId, fan_id, fan_dict):
                             logger.error(f"Failed to write fan config {profile.profileId}/{fan_id}")
                             success = False
-            
+
             # Apply RGB profiles
             if device_config.rgbProfiles:
                 for rgb in device_config.rgbProfiles:
                     rgb_dict = rgb.model_dump()
                     profile_id = rgb_dict.pop('profileId')
-                    
+
                     if not client.write_rgb_config(profile_id, rgb_dict):
                         logger.error(f"Failed to write RGB config {profile_id}")
                         success = False
-            
+
             # Apply calibration
             if device_config.calibration:
                 if not client.write_calibration(device_config.calibration):
                     logger.error("Failed to write calibration")
                     success = False
-            
+
             # Determine whether to save to flash (override takes precedence)
             should_save = save_to_flash if save_to_flash is not None else device_config.saveToFlash
-            
+
             if should_save:
                 if not client.save_config():
                     logger.error("Failed to save config to flash")
                     success = False
                 else:
                     logger.info("Configuration saved to flash")
-            
-            client.close()
+
             return success
-            
+
         except Exception as e:
             logger.error(f"Failed to apply device config: {e}")
             return False
+        finally:
+            client.close()

--- a/benchlab/config/config_tool.py
+++ b/benchlab/config/config_tool.py
@@ -54,13 +54,13 @@ def cmd_import(args):
     if not Path(args.config_file).exists():
         print(f"ERROR: Config file not found: {args.config_file}")
         return 1
-    
+
     manager = ConfigManager(source=args.source)
-    
+
     if args.dry_run:
-        print("DRY RUN MODE - No changes will be applied")
-    
-    if manager.import_config(args.config_file, dry_run=args.dry_run):
+        print("DRY RUN MODE - showing what would change, no changes will be applied")
+
+    if manager.import_config(args.config_file, dry_run=args.dry_run, auto_confirm=args.yes):
         if not args.dry_run:
             print("SUCCESS: Configuration applied")
         return 0
@@ -147,26 +147,17 @@ def interactive_mode(args):
             print()
             input("Press Enter to exit...")
             return 1
-        
-        # Confirm before applying
-        print()
-        print(f"Configuration file: {config_file}")
-        print("Apply this configuration? (yes/no)")
-        confirm = input("> ").strip().lower()
-        
-        if confirm not in ('yes', 'y'):
-            print("Cancelled.")
-            return 0
-        
-        # Ask about saving to flash
+
+        # Ask about saving to flash up front, so import_config's per-device
+        # diff/confirm below is the only remaining approval step.
         print()
         print("Save configuration to device flash memory?")
         print("(If 'no', changes will only be applied to RAM and lost on device reset)")
         save_flash = input("Save to flash? (yes/no): ").strip().lower()
-        
-        # Apply configuration
+
+        # Read + diff + confirm happens per device inside import_config,
+        # which prints the diff and prompts before applying each one.
         print()
-        print("Applying configuration...")
         if manager.import_config(config_file, dry_run=False, save_to_flash=(save_flash in ('yes', 'y'))):
             print()
             if save_flash in ('yes', 'y'):
@@ -262,25 +253,30 @@ def main(args=None):
 Examples:
   # List devices
   python benchlab.py -config --list
-  
+
   # Export configuration
   python benchlab.py -config --export config.json
   python benchlab.py -config --export config.json --device COM4
-  
-  # Import configuration
+
+  # Import configuration (shows a diff of what would change, then asks to confirm)
   python benchlab.py -config --import config.json
+
+  # Preview changes without applying anything
   python benchlab.py -config --import config.json --dry-run
-  
+
+  # Apply without the confirmation prompt (for scripts/automation)
+  python benchlab.py -config --import config.json --yes
+
   # Use named pipe source (Windows only)
   python benchlab.py -config --list --source named_pipe
   python benchlab.py -config --import config.json --source named_pipe
             """
         )
-        
-        parser.add_argument('--source', choices=['direct', 'named_pipe'], 
+
+        parser.add_argument('--source', choices=['direct', 'named_pipe'],
                           default='direct',
                           help='Data source type (default: direct)')
-        
+
         # Commands
         parser.add_argument('--list', action='store_true',
                           help='List available devices')
@@ -288,13 +284,15 @@ Examples:
                           help='Export configuration to JSON file')
         parser.add_argument('--import', metavar='FILE', dest='config_file',
                           help='Import configuration from JSON file')
-        
+
         # Options
         parser.add_argument('--device', metavar='ID',
                           help='Device identifier (port or pipe name)')
         parser.add_argument('--dry-run', action='store_true',
-                          help='Validate configuration without applying')
-        
+                          help='Show what would change without applying anything (connects to the device and reads its current config)')
+        parser.add_argument('-y', '--yes', action='store_true',
+                          help='Apply changes without the confirmation prompt (the diff is still shown)')
+
         args = parser.parse_args()
     else:
         # Called from launcher - add missing command attributes
@@ -311,6 +309,8 @@ Examples:
             args.device = None
         if not hasattr(args, 'dry_run'):
             args.dry_run = False
+        if not hasattr(args, 'yes'):
+            args.yes = False
     
     # If no command specified, run interactive mode
     if not (args.list or args.output or args.config_file):

--- a/benchlab/config/diff.py
+++ b/benchlab/config/diff.py
@@ -1,0 +1,143 @@
+"""
+Configuration Diff
+
+Computes and renders a field-level diff between a device's current state
+(as read by ConfigManager._read_current_state) and the desired state from
+a config file, so users see exactly what would change before applying.
+"""
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+
+@dataclass
+class FieldChange:
+    field: str
+    current: Any
+    desired: Any
+
+
+@dataclass
+class DiffResult:
+    device_name_change: Optional[FieldChange] = None
+    # (profileId, fanId) -> list of FieldChange
+    fan_changes: Dict[Tuple[int, int], List[FieldChange]] = field(default_factory=dict)
+    # profileId -> list of FieldChange
+    rgb_changes: Dict[int, List[FieldChange]] = field(default_factory=dict)
+    calibration_changed: bool = False
+    read_errors: List[str] = field(default_factory=list)
+
+    def is_empty(self) -> bool:
+        return not (
+            self.device_name_change
+            or self.fan_changes
+            or self.rgb_changes
+            or self.calibration_changed
+        )
+
+
+def _dict_diff(current: Dict[str, Any], desired: Dict[str, Any], skip_keys=()) -> List[FieldChange]:
+    """Return FieldChanges for keys present in *desired* whose value differs
+    from *current* (missing-in-current counts as a difference, e.g. first
+    import onto a fresh device)."""
+    changes = []
+    for k, desired_v in desired.items():
+        if k in skip_keys:
+            continue
+        current_v = current.get(k) if current else None
+        if current_v != desired_v:
+            changes.append(FieldChange(field=k, current=current_v, desired=desired_v))
+    return changes
+
+
+def compute_diff(current_state: Dict[str, Any], desired_device_config) -> DiffResult:
+    """Compare a device's current state against a DeviceConfig (pydantic model).
+
+    Args:
+        current_state: dict as returned by ConfigManager._read_current_state
+                        (deviceName, fanProfiles, rgbProfiles, calibration, readErrors)
+        desired_device_config: schema.DeviceConfig instance from the loaded config file
+
+    Returns:
+        DiffResult describing only the fields that differ.
+    """
+    result = DiffResult(read_errors=list(current_state.get('readErrors', [])))
+
+    # Device name
+    if desired_device_config.deviceName is not None:
+        current_name = current_state.get('deviceName')
+        if current_name != desired_device_config.deviceName:
+            result.device_name_change = FieldChange(
+                field='deviceName', current=current_name, desired=desired_device_config.deviceName
+            )
+
+    # Fan profiles: index current by (profileId, fanId)
+    current_fans: Dict[Tuple[int, int], Dict[str, Any]] = {}
+    for profile in (current_state.get('fanProfiles') or []):
+        pid = profile.get('profileId')
+        for fan in profile.get('fans', []):
+            current_fans[(pid, fan.get('fanId'))] = fan
+
+    for profile in (desired_device_config.fanProfiles or []):
+        for fan in profile.fans:
+            key = (profile.profileId, fan.fanId)
+            fan_dict = fan.model_dump()
+            changes = _dict_diff(current_fans.get(key, {}), fan_dict, skip_keys=('fanId',))
+            if changes:
+                result.fan_changes[key] = changes
+
+    # RGB profiles: index current by profileId
+    current_rgb: Dict[int, Dict[str, Any]] = {
+        rgb.get('profileId'): rgb for rgb in (current_state.get('rgbProfiles') or [])
+    }
+    for rgb in (desired_device_config.rgbProfiles or []):
+        rgb_dict = rgb.model_dump()
+        changes = _dict_diff(current_rgb.get(rgb.profileId, {}), rgb_dict, skip_keys=('profileId',))
+        if changes:
+            result.rgb_changes[rgb.profileId] = changes
+
+    # Calibration: whole-blob comparison, not meant to be hand-edited field by field
+    if desired_device_config.calibration is not None:
+        if current_state.get('calibration') != desired_device_config.calibration:
+            result.calibration_changed = True
+
+    return result
+
+
+def format_diff(diff: DiffResult, device_label: str) -> str:
+    """Render a DiffResult as human-readable text."""
+    lines = [f"Changes to be applied ({device_label}):"]
+    has_content = False
+
+    if diff.device_name_change:
+        has_content = True
+        c = diff.device_name_change
+        lines.append(f"  Device Name:")
+        lines.append(f"    {c.current!r} -> {c.desired!r}")
+
+    for (profile_id, fan_id), changes in sorted(diff.fan_changes.items()):
+        has_content = True
+        lines.append(f"  Fan {fan_id} Profile {profile_id}:")
+        for c in changes:
+            lines.append(f"    {c.field}: {c.current} -> {c.desired}")
+
+    for profile_id, changes in sorted(diff.rgb_changes.items()):
+        has_content = True
+        lines.append(f"  RGB Profile {profile_id}:")
+        for c in changes:
+            lines.append(f"    {c.field}: {c.current} -> {c.desired}")
+
+    if diff.calibration_changed:
+        has_content = True
+        lines.append("  Calibration: (changed)")
+
+    if not has_content:
+        lines.append("  No changes.")
+
+    if diff.read_errors:
+        lines.append("")
+        lines.append("  Warning: could not read current state for:")
+        for err in diff.read_errors:
+            lines.append(f"    - {err}")
+
+    return "\n".join(lines)

--- a/benchlab/config/test_config_client.py
+++ b/benchlab/config/test_config_client.py
@@ -1,0 +1,96 @@
+"""Non-hardware regression tests for benchlab.config.config_client.
+
+Covers the BL2 vs Original calibration struct selection bug fixed in the
+config bug sweep (issue #32): write_calibration used to always reconstruct
+a plain CalibrationStruct (Original, 4 temp sensors) regardless of the
+connected device's actual product_id, even though benchlab-pycore has a
+distinct CalibrationStructBL2 (8 temp sensors) for BL2 devices and
+read_calibration already selected the right one. Uses the real
+benchlab-pycore struct types (a hard dependency of this module) but no
+real serial device -- write_calibration is invoked directly on an instance
+built without going through __init__'s serial connection.
+"""
+
+import pytest
+
+pytest.importorskip("benchlab_pycore")
+
+from benchlab_pycore.core import (
+    CalibrationStruct, CalibrationStructBL2,
+    BENCHLAB_BL2_PRODUCT_ID, BENCHLAB_ORIGINAL_PRODUCT_ID,
+)
+
+from benchlab.config.config_client import DirectConfigClient
+
+
+def _make_client(product_id):
+    """Construct a DirectConfigClient without running __init__ (which opens
+    a real serial connection) -- just set the attributes write_calibration
+    actually needs."""
+    client = DirectConfigClient.__new__(DirectConfigClient)
+    client.product_id = product_id
+    client.ser = None
+    return client
+
+
+def test_write_calibration_selects_bl2_struct_for_bl2_device(monkeypatch):
+    """Regression test: BL2-shaped calibration data (8 temp sensors) used
+    to be forced into the Original 4-sensor struct, raising IndexError."""
+    client = _make_client(BENCHLAB_BL2_PRODUCT_ID)
+
+    captured = {}
+    def fake_write_calibration(ser, calibration, product_id=None):
+        captured["struct_type"] = type(calibration)
+        return True
+    monkeypatch.setattr("benchlab_pycore.core.write_calibration", fake_write_calibration)
+
+    cal_dict = {
+        "Crc": 0,
+        "Ts": [{"Offset": i, "GainOffset": 0} for i in range(8)],  # BL2 has 8 sensors
+    }
+
+    result = client.write_calibration(cal_dict)
+
+    assert result is True
+    assert captured["struct_type"] is CalibrationStructBL2
+
+
+def test_write_calibration_selects_original_struct_for_original_device(monkeypatch):
+    client = _make_client(BENCHLAB_ORIGINAL_PRODUCT_ID)
+
+    captured = {}
+    def fake_write_calibration(ser, calibration, product_id=None):
+        captured["struct_type"] = type(calibration)
+        return True
+    monkeypatch.setattr("benchlab_pycore.core.write_calibration", fake_write_calibration)
+
+    cal_dict = {
+        "Crc": 0,
+        "Ts": [{"Offset": i, "GainOffset": 0} for i in range(4)],  # Original has 4 sensors
+    }
+
+    result = client.write_calibration(cal_dict)
+
+    assert result is True
+    assert captured["struct_type"] is CalibrationStruct
+
+
+def test_write_calibration_bl2_data_no_longer_raises_indexerror():
+    """Directly reproduces the original bug scenario: reconstructing
+    8-sensor calibration data now succeeds when the client knows it's
+    talking to a BL2 device, instead of raising IndexError against the
+    4-sensor Original struct."""
+    client = _make_client(BENCHLAB_BL2_PRODUCT_ID)
+
+    cal_dict = {
+        "Crc": 0,
+        "Ts": [{"Offset": i, "GainOffset": 0} for i in range(8)],
+    }
+
+    # _dict_to_struct is the piece that previously raised IndexError when
+    # forced into the wrong (4-sensor) struct type; call it directly with
+    # the now-correct struct type to confirm reconstruction succeeds.
+    struct_type = CalibrationStructBL2 if client.product_id == BENCHLAB_BL2_PRODUCT_ID else CalibrationStruct
+    result = client._dict_to_struct(cal_dict, struct_type)
+
+    assert len(result.Ts) == 8

--- a/benchlab/config/test_config_manager.py
+++ b/benchlab/config/test_config_manager.py
@@ -1,0 +1,107 @@
+"""Non-hardware regression tests for benchlab.config.config_manager.
+
+These tests exercise the bugs fixed in the config bug sweep (issue #32)
+with mocked ConfigClient instances -- no real device or hardware needed:
+- select_device()'s productId selector on the direct source now warns
+  clearly instead of silently returning None
+- export_config()/_apply_device_config() close the client even when it
+  raises mid-operation
+- import_config()'s new diff-before-apply flow (dry_run / auto_confirm /
+  confirm_callback)
+"""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from benchlab.config.config_manager import ConfigManager
+
+
+def test_select_device_productid_on_direct_logs_warning_and_returns_none(caplog):
+    """Regression test for issue #32: productId selector used to be a
+    silent no-op (`pass`) for the direct source, giving no indication of
+    why device selection failed."""
+    mgr = ConfigManager(source="direct")
+    devices = [{"port": "COM4", "uid": "ABC123"}]
+
+    with caplog.at_level(logging.WARNING):
+        result = mgr.select_device({"type": "productId", "value": 0x10}, devices)
+
+    assert result is None
+    assert any("productId" in rec.message for rec in caplog.records)
+
+
+def test_select_device_productid_still_works_on_named_pipe():
+    mgr = ConfigManager(source="named_pipe")
+    devices = [{"pipe": "BenchlabSensorPipe_10_1234", "productId": 0x10}]
+
+    result = mgr.select_device({"type": "productId", "value": 0x10}, devices)
+
+    assert result == "BenchlabSensorPipe_10_1234"
+
+
+def test_select_device_guid_matches_on_direct():
+    mgr = ConfigManager(source="direct")
+    devices = [{"port": "COM4", "uid": "ABC123"}]
+
+    result = mgr.select_device({"type": "guid", "value": "ABC123"}, devices)
+
+    assert result == "COM4"
+
+
+def test_select_device_any_returns_first():
+    mgr = ConfigManager(source="direct")
+    devices = [{"port": "COM4", "uid": "A"}, {"port": "COM5", "uid": "B"}]
+
+    result = mgr.select_device({"type": "any", "value": None}, devices)
+
+    assert result == "COM4"
+
+
+def test_export_config_closes_client_on_exception():
+    """Regression test for issue #32: export_config used to leak the
+    client (open serial port / pipe handle) if any read raised, since
+    client.close() was only called at the end of the try block."""
+    mgr = ConfigManager(source="direct")
+    fake_client = MagicMock()
+    fake_client.get_device_info.side_effect = RuntimeError("simulated read failure")
+
+    with patch("benchlab.config.config_manager.create_config_client", return_value=fake_client):
+        result = mgr.export_config("COM4", "unused_output.json")
+
+    assert result is False
+    fake_client.close.assert_called_once()
+
+
+def test_apply_device_config_closes_client_on_exception():
+    from benchlab.config.schema import DeviceConfig, DeviceSelector
+
+    mgr = ConfigManager(source="direct")
+    fake_client = MagicMock()
+    fake_client.write_device_name.side_effect = RuntimeError("simulated write failure")
+
+    device_config = DeviceConfig(selector=DeviceSelector(type="any"), deviceName="Test")
+
+    with patch("benchlab.config.config_manager.create_config_client", return_value=fake_client):
+        result = mgr._apply_device_config("COM4", device_config)
+
+    assert result is False
+    fake_client.close.assert_called_once()
+
+
+def test_read_current_state_tolerates_partial_failures():
+    """A failure reading one section (e.g. calibration) must not prevent
+    the other sections from being read and returned."""
+    mgr = ConfigManager(source="direct")
+    fake_client = MagicMock()
+    fake_client.read_device_name.return_value = "MyDevice"
+    fake_client.read_fan_config.return_value = None
+    fake_client.read_rgb_config.return_value = None
+    fake_client.read_calibration.side_effect = RuntimeError("calibration read timeout")
+
+    state = mgr._read_current_state(fake_client)
+
+    assert state["deviceName"] == "MyDevice"
+    assert state["calibration"] is None
+    assert any("calibration" in err for err in state["readErrors"])

--- a/benchlab/config/test_diff.py
+++ b/benchlab/config/test_diff.py
@@ -1,0 +1,170 @@
+"""Non-hardware regression tests for benchlab.config.diff.
+
+Pure logic tests -- no device, no I/O. Covers compute_diff() correctly
+identifying changed/unchanged fields across device name, fan profiles, RGB
+profiles, and calibration, and format_diff()'s rendering including the
+"no changes" case.
+"""
+
+from benchlab.config.schema import DeviceConfig, DeviceSelector, FanProfile, FanConfig, RGBConfig
+from benchlab.config.diff import compute_diff, format_diff
+
+
+def _selector():
+    return DeviceSelector(type="any")
+
+
+def _empty_state():
+    return {
+        "deviceName": None,
+        "fanProfiles": None,
+        "rgbProfiles": None,
+        "calibration": None,
+        "readErrors": [],
+    }
+
+
+def test_no_changes_when_desired_matches_current():
+    current = {
+        "deviceName": "SameName",
+        "fanProfiles": None,
+        "rgbProfiles": None,
+        "calibration": None,
+        "readErrors": [],
+    }
+    desired = DeviceConfig(selector=_selector(), deviceName="SameName")
+
+    diff = compute_diff(current, desired)
+
+    assert diff.is_empty()
+    assert "No changes" in format_diff(diff, "COM4")
+
+
+def test_device_name_change_detected():
+    current = {**_empty_state(), "deviceName": "OldName"}
+    desired = DeviceConfig(selector=_selector(), deviceName="NewName")
+
+    diff = compute_diff(current, desired)
+
+    assert not diff.is_empty()
+    assert diff.device_name_change is not None
+    assert diff.device_name_change.current == "OldName"
+    assert diff.device_name_change.desired == "NewName"
+
+
+def test_device_name_unset_in_desired_is_not_a_change():
+    current = {**_empty_state(), "deviceName": "ExistingName"}
+    desired = DeviceConfig(selector=_selector())  # deviceName defaults to None
+
+    diff = compute_diff(current, desired)
+
+    assert diff.device_name_change is None
+
+
+def test_fan_config_change_detected_per_fan():
+    current = {
+        **_empty_state(),
+        "fanProfiles": [{
+            "profileId": 0,
+            "fans": [{
+                "fanId": 0, "FanMode": 0, "TempSource": 0, "Temp": [300, 600],
+                "Duty": [30, 80], "RampStep": 5, "FixedDuty": 50,
+                "MinDuty": 20, "MaxDuty": 100, "FanStop": 0,
+            }],
+        }],
+    }
+    desired = DeviceConfig(
+        selector=_selector(),
+        fanProfiles=[FanProfile(profileId=0, fans=[
+            FanConfig(fanId=0, FanMode=1, TempSource=0, Duty=[40, 90]),
+        ])],
+    )
+
+    diff = compute_diff(current, desired)
+
+    assert (0, 0) in diff.fan_changes
+    changed_fields = {c.field for c in diff.fan_changes[(0, 0)]}
+    assert "FanMode" in changed_fields
+    assert "Duty" in changed_fields
+    assert "TempSource" not in changed_fields  # unchanged, should not appear
+
+
+def test_fan_config_new_fan_shows_full_diff():
+    """A fan present in desired but absent from current (fresh device /
+    never-configured profile) should show as a change, not error."""
+    current = _empty_state()
+    desired = DeviceConfig(
+        selector=_selector(),
+        fanProfiles=[FanProfile(profileId=0, fans=[FanConfig(fanId=0, FanMode=1, TempSource=0)])],
+    )
+
+    diff = compute_diff(current, desired)
+
+    assert (0, 0) in diff.fan_changes
+
+
+def test_rgb_config_change_detected():
+    current = {
+        **_empty_state(),
+        "rgbProfiles": [{"profileId": 0, "Mode": 9, "Red": 255, "Green": 0, "Blue": 0, "Direction": 0, "Speed": 50}],
+    }
+    desired = DeviceConfig(
+        selector=_selector(),
+        rgbProfiles=[RGBConfig(profileId=0, Mode=5, Red=0, Green=0, Blue=255, Direction=0, Speed=50)],
+    )
+
+    diff = compute_diff(current, desired)
+
+    assert 0 in diff.rgb_changes
+    changed_fields = {c.field for c in diff.rgb_changes[0]}
+    assert "Mode" in changed_fields
+    assert "Blue" in changed_fields
+    assert "Green" not in changed_fields  # unchanged
+
+
+def test_calibration_change_detected_as_whole_blob():
+    current = {**_empty_state(), "calibration": {"Crc": 1}}
+    desired = DeviceConfig(selector=_selector(), calibration={"Crc": 2})
+
+    diff = compute_diff(current, desired)
+
+    assert diff.calibration_changed is True
+
+
+def test_calibration_unset_in_desired_is_not_a_change():
+    current = {**_empty_state(), "calibration": {"Crc": 1}}
+    desired = DeviceConfig(selector=_selector())  # calibration defaults to None
+
+    diff = compute_diff(current, desired)
+
+    assert diff.calibration_changed is False
+
+
+def test_read_errors_propagated_to_diff_and_format():
+    current = {**_empty_state(), "readErrors": ["calibration: timeout"]}
+    desired = DeviceConfig(selector=_selector())
+
+    diff = compute_diff(current, desired)
+    text = format_diff(diff, "COM4")
+
+    assert diff.read_errors == ["calibration: timeout"]
+    assert "calibration: timeout" in text
+    assert "Warning" in text
+
+
+def test_format_diff_renders_fan_and_rgb_sections():
+    current = _empty_state()
+    desired = DeviceConfig(
+        selector=_selector(),
+        deviceName="NewName",
+        fanProfiles=[FanProfile(profileId=1, fans=[FanConfig(fanId=2, FanMode=1, TempSource=0)])],
+        rgbProfiles=[RGBConfig(profileId=0, Mode=5, Red=1, Green=2, Blue=3, Direction=0, Speed=10)],
+    )
+
+    diff = compute_diff(current, desired)
+    text = format_diff(diff, "COM4 - Test")
+
+    assert "COM4 - Test" in text
+    assert "Fan 2 Profile 1" in text
+    assert "RGB Profile 0" in text
+    assert "Device Name" in text


### PR DESCRIPTION
## Summary

**Bug sweep (#32)** — found while verifying `benchlab/config` against the latest `benchlab-pycore` (0.5.1) and the real named-pipe service protocol (`BENCHLAB.BENCHLAB_Service`, `dev-blcfe` branch, fetched and read directly). The named-pipe command protocol itself matches the real service exactly (command names, field names, framing, enum serialization). Five real issues found instead:

- `write_calibration` hardcoded the Original `CalibrationStruct` (4 temp sensors) regardless of the connected device's actual product ID, even though `benchlab-pycore` has a distinct `CalibrationStructBL2` (8 sensors) and `read_calibration` already selected the right one — importing calibration to a BL2 device raised `IndexError`.
- `select_device()`'s `productId` selector silently no-op'd on the `direct` source instead of explaining why it can't match (product ID isn't available from fleet discovery without connecting first).
- `export_config()`/`_apply_device_config()` could leak the client (open serial port / pipe handle) if a read/write raised mid-operation.
- `_discover_named_pipe()` listed local pipes and queried each device individually instead of using the service's dedicated `BenchlabDiscovery`/`ListDevices` round-trip.
- `README.md` linked to two files that don't exist.

**Diff-before-apply UX (#33)** — `--import` now reads the device's current state, computes a field-level diff against the desired JSON config, and prints it before applying, instead of blindly writing. `--dry-run` now performs this same read+diff but stops before applying (previously it only validated JSON schema, with no device contact at all). New `-y`/`--yes` flag skips the confirmation prompt for scripted/automated use — documented in `--help`. Partial read failures show the diff for whatever succeeded and warn about what didn't, matching `export_config()`'s existing tolerant pattern.

## Test plan

- [x] `pytest benchlab/config/test_diff.py -v` — 10 tests, pure diff-logic
- [x] `pytest benchlab/config/test_config_manager.py -v` — 7 tests, mocked-client
- [x] `pytest benchlab/config/test_config_client.py -v` — 3 tests, real pycore struct types
- [x] Regression-verified: reverted the `client.close()` `try/finally` and confirmed `test_apply_device_config_closes_client_on_exception` fails; restored and confirmed it passes
- [x] Regression-verified: reverted the BL2 struct-selection fix and confirmed `test_write_calibration_selects_bl2_struct_for_bl2_device` fails with the original `IndexError`-class error; restored and confirmed it passes
- [x] Full repo regression suite (106 tests across config/vu/mqtt/wigidash/hwinfo/graph) passes
- [x] `pycore-compat.yml` updated in both `pinned` and `latest` jobs — import smoke test + 3 new pytest steps each
- [ ] CI green on this PR