### PR TITLE
Fix launcher bug sweep: Windows cleanup, direct source check, leaks

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -35,6 +35,8 @@ jobs:
         run: >
           python -c "import benchlab.core, benchlab.core.discovery,
           benchlab.core.datasource, benchlab.core.shared_serial,
+          benchlab.main, benchlab.launcher, benchlab.menu, benchlab.tools,
+          benchlab.sources,
           benchlab.config.config_client, benchlab.config.config_manager,
           benchlab.config.diff, benchlab.restapi.telemetry_api,
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export,
@@ -97,6 +99,9 @@ jobs:
 
       - name: Test - config client (calibration struct selection)
         run: pytest benchlab/config/test_config_client.py -v
+
+      - name: Test - launcher bug sweep
+        run: pytest tests/test_launcher.py -v
 
   latest:
     name: Import + test against latest pycore (PyPI)
@@ -122,6 +127,8 @@ jobs:
         run: >
           python -c "import benchlab.core, benchlab.core.discovery,
           benchlab.core.datasource, benchlab.core.shared_serial,
+          benchlab.main, benchlab.launcher, benchlab.menu, benchlab.tools,
+          benchlab.sources,
           benchlab.config.config_client, benchlab.config.config_manager,
           benchlab.config.diff, benchlab.restapi.telemetry_api,
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export,
@@ -184,3 +191,6 @@ jobs:
 
       - name: Test - config client (calibration struct selection)
         run: pytest benchlab/config/test_config_client.py -v
+
+      - name: Test - launcher bug sweep
+        run: pytest tests/test_launcher.py -v

--- a/benchlab/__init__.py
+++ b/benchlab/__init__.py
@@ -2,4 +2,13 @@
 BENCHLAB Telemetry Package
 """
 
+import os as _os
+import sys as _sys
+
+# Ensure the repo root (containing bootstrap.py) is importable. Centralized
+# here so menu.py/tools.py don't each need their own sys.path.insert hack.
+_repo_root = _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__)))
+if _repo_root not in _sys.path:
+    _sys.path.insert(0, _repo_root)
+
 __version__ = "0.8.2"

--- a/benchlab/launcher.py
+++ b/benchlab/launcher.py
@@ -52,6 +52,29 @@ def _monitor_process(tool_name: str, proc: subprocess.Popen) -> None:
             logger.error(f"[{tool_name}] {line}")
 
 
+def _terminate_spawned_process(proc: subprocess.Popen, force: bool) -> None:
+    """Terminate a spawned terminal-window process (and its children).
+
+    os.killpg/os.getpgid don't exist on Windows, so this mirrors
+    ProcessManager's platform branch: taskkill /T kills the whole
+    process tree rooted at the terminal emulator's PID on Windows,
+    while POSIX uses the process group created via preexec_fn=os.setsid.
+    """
+    try:
+        if not proc or proc.poll() is not None:
+            return
+        if sys.platform == "win32":
+            subprocess.run(
+                ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                capture_output=True,
+            )
+        else:
+            sig = signal.SIGKILL if force else signal.SIGTERM
+            os.killpg(os.getpgid(proc.pid), sig)
+    except Exception:
+        pass
+
+
 # ──────────────────────────────────────────────────────────────
 # Single-tool Launch (in-process, blocking)
 # ──────────────────────────────────────────────────────────────
@@ -316,20 +339,12 @@ def launch_tools_concurrent(tool_ids: List[str], source_ready_delay: float = 2.0
         logger.info("Stopping all tools...")
 
         for proc in processes.values():
-            try:
-                if proc and proc.poll() is None:
-                    os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
-            except Exception:
-                pass
+            _terminate_spawned_process(proc, force=False)
 
         time.sleep(1)
 
         for proc in processes.values():
-            try:
-                if proc and proc.poll() is None:
-                    os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-            except Exception:
-                pass
+            _terminate_spawned_process(proc, force=True)
 
         cleanup_all_services()
 

--- a/benchlab/main.py
+++ b/benchlab/main.py
@@ -159,6 +159,31 @@ def _setup_source_from_args(args) -> bool:
     return ready
 
 
+def _export_link_env(args) -> None:
+    """Mirror --remote-*/--no-tls/--topic-pattern CLI flags into env vars.
+
+    link_main.py's _resolve_config already falls back to these env vars
+    (REMOTE_MQTT_HOST etc.) when no args object provides a value, so
+    exporting here is what lets a spawned/multi-tool `link` process
+    (launched via launcher.py's _spawn_tool_in_terminal, which parses
+    fresh argv with none of these flags) still pick up the config the
+    user passed on the parent process's command line.
+    """
+    mapping = {
+        "remote_host": "REMOTE_MQTT_HOST",
+        "remote_port": "REMOTE_MQTT_PORT",
+        "remote_user": "REMOTE_MQTT_USER",
+        "remote_pass": "REMOTE_MQTT_PASS",
+        "topic_pattern": "LINK_TOPIC_PATTERN",
+    }
+    for attr, env_key in mapping.items():
+        val = getattr(args, attr, None)
+        if val is not None:
+            os.environ[env_key] = str(val)
+    if getattr(args, "no_tls", False):
+        os.environ["REMOTE_MQTT_TLS"] = "false"
+
+
 # ──────────────────────────────────────────────────────────────
 # Per-tool CLI Dispatch Helpers
 # ──────────────────────────────────────────────────────────────
@@ -263,6 +288,7 @@ def launch_mode() -> None:
             print("MQTT module not available in this build.")
 
     elif args.link:
+        _export_link_env(args)
         _run_with_source(args,
                          "benchlab.link.link_main", "run_link",
                          lambda fn: fn(args), "Link")

--- a/benchlab/menu.py
+++ b/benchlab/menu.py
@@ -11,9 +11,6 @@ import os
 import sys
 from typing import List, Optional
 
-import sys as _sys
-import os as _os
-_sys.path.insert(0, _os.path.dirname(_os.path.dirname(__file__)))
 from bootstrap import clear_screen
 from .tools import CONSUMER_TOOLS
 from .sources import (

--- a/benchlab/sources.py
+++ b/benchlab/sources.py
@@ -244,6 +244,7 @@ def check_named_pipe_service() -> bool:
         return False
 
     # Quick smoke-test: open the pipe and send ListDevices
+    handle = None
     try:
         import win32file
         import win32pipe
@@ -260,12 +261,17 @@ def check_named_pipe_service() -> bool:
         )
         win32file.WriteFile(handle, b"ListDevices\n")
         _, data = win32file.ReadFile(handle, 65536)
-        win32file.CloseHandle(handle)
         result = json.loads(data.split(b"\n")[0].decode("utf-8"))
         return isinstance(result, list)
     except Exception as e:
         logger.debug(f"Named pipe smoke-test failed: {e}")
         return False
+    finally:
+        if handle is not None:
+            try:
+                win32file.CloseHandle(handle)
+            except Exception:
+                pass
 
 
 # ──────────────────────────────────────────────────────────────
@@ -308,6 +314,16 @@ def check_service_http() -> bool:
     return _service_http_health()
 
 
+def _direct_device_available() -> bool:
+    """Return True if pycore can see a BENCHLAB device on any serial port."""
+    try:
+        from benchlab_pycore.core import get_benchlab_ports
+        return len(get_benchlab_ports()) > 0
+    except Exception as e:
+        logger.debug(f"Direct device scan failed: {e}")
+        return False
+
+
 # ──────────────────────────────────────────────────────────────
 # Unified Source Setup
 # ──────────────────────────────────────────────────────────────
@@ -327,6 +343,11 @@ def check_and_setup_source(source_type: str, **kwargs) -> bool:
     """
     if source_type == "direct":
         os.environ["BENCHLAB_DATA_SOURCE"] = "direct"
+        if not _direct_device_available():
+            logger.warning(
+                "No BENCHLAB device detected on any serial port. "
+                "Plug in a device or select a different data source."
+            )
         return True
 
     if source_type == "fastapi":

--- a/benchlab/tools.py
+++ b/benchlab/tools.py
@@ -9,9 +9,6 @@ import importlib.util
 import logging
 from pathlib import Path
 
-import sys as _sys
-import os as _os
-_sys.path.insert(0, _os.path.dirname(_os.path.dirname(__file__)))
 from bootstrap import install_requirements_file
 
 logger = logging.getLogger("benchlab.launcher")

--- a/tests/test_launcher.py
+++ b/tests/test_launcher.py
@@ -1,0 +1,180 @@
+"""Non-hardware regression tests for the launcher bug sweep (issue #35).
+
+Covers:
+- launcher.py's _terminate_spawned_process correctly branches on platform
+  instead of unconditionally calling os.killpg/os.getpgid (which don't
+  exist on Windows and previously made spawned-terminal cleanup a silent
+  no-op there).
+- main.py's _export_link_env mirrors --remote-*/--no-tls/--topic-pattern
+  CLI flags into the env vars link_main.py's _resolve_config already
+  reads, so a spawned `link` subprocess (fresh argv, no CLI flags) still
+  picks up the parent process's config.
+- sources.py's check_and_setup_source("direct") now warns when no device
+  is detected instead of unconditionally reporting ready.
+- sources.py's check_named_pipe_service closes its pipe handle even when
+  WriteFile/ReadFile raises after CreateFile succeeds.
+"""
+
+import os
+import subprocess
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from benchlab.launcher import _terminate_spawned_process
+from benchlab.main import _export_link_env
+
+
+def _fake_running_proc():
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.poll.return_value = None
+    proc.pid = 4242
+    return proc
+
+
+def test_terminate_spawned_process_windows_uses_taskkill():
+    proc = _fake_running_proc()
+    with patch.object(sys, "platform", "win32"), \
+         patch("benchlab.launcher.subprocess.run") as mock_run:
+        _terminate_spawned_process(proc, force=False)
+    mock_run.assert_called_once()
+    cmd = mock_run.call_args[0][0]
+    assert cmd[0] == "taskkill"
+    assert str(proc.pid) in cmd
+
+
+def test_terminate_spawned_process_posix_uses_killpg():
+    # os.killpg/os.getpgid/signal.SIGKILL don't exist on Windows (this test
+    # may run there), so patch with create=True to simulate the POSIX
+    # branch regardless of host OS.
+    proc = _fake_running_proc()
+    with patch.object(sys, "platform", "linux"), \
+         patch("benchlab.launcher.os.getpgid", return_value=99, create=True) as mock_getpgid, \
+         patch("benchlab.launcher.os.killpg", create=True) as mock_killpg, \
+         patch("benchlab.launcher.signal.SIGKILL", 9, create=True), \
+         patch("benchlab.launcher.signal.SIGTERM", 15, create=True):
+        _terminate_spawned_process(proc, force=True)
+    mock_getpgid.assert_called_once_with(proc.pid)
+    mock_killpg.assert_called_once()
+
+
+def test_terminate_spawned_process_never_raises_on_failure():
+    """Regression: the old code's bare except swallowed AttributeError from
+    os.killpg not existing on Windows, making cleanup a permanent no-op.
+    The new helper must still never raise, but should attempt the correct
+    platform call rather than always failing."""
+    proc = _fake_running_proc()
+    with patch.object(sys, "platform", "win32"), \
+         patch("benchlab.launcher.subprocess.run", side_effect=OSError("boom")):
+        _terminate_spawned_process(proc, force=False)  # must not raise
+
+
+def test_terminate_spawned_process_skips_already_exited():
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.poll.return_value = 0
+    with patch("benchlab.launcher.subprocess.run") as mock_run, \
+         patch("benchlab.launcher.os.killpg", create=True) as mock_killpg:
+        _terminate_spawned_process(proc, force=False)
+    mock_run.assert_not_called()
+    mock_killpg.assert_not_called()
+
+
+@pytest.fixture(autouse=True)
+def _clean_link_env():
+    keys = ["REMOTE_MQTT_HOST", "REMOTE_MQTT_PORT", "REMOTE_MQTT_USER",
+             "REMOTE_MQTT_PASS", "LINK_TOPIC_PATTERN", "REMOTE_MQTT_TLS"]
+    saved = {k: os.environ.pop(k, None) for k in keys}
+    yield
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def test_export_link_env_sets_provided_fields():
+    args = types.SimpleNamespace(
+        remote_host="broker.example.com", remote_port=8883,
+        remote_user="u", remote_pass="p", topic_pattern="x/{uid}/y",
+        no_tls=True,
+    )
+    _export_link_env(args)
+    assert os.environ["REMOTE_MQTT_HOST"] == "broker.example.com"
+    assert os.environ["REMOTE_MQTT_PORT"] == "8883"
+    assert os.environ["REMOTE_MQTT_USER"] == "u"
+    assert os.environ["REMOTE_MQTT_PASS"] == "p"
+    assert os.environ["LINK_TOPIC_PATTERN"] == "x/{uid}/y"
+    assert os.environ["REMOTE_MQTT_TLS"] == "false"
+
+
+def test_export_link_env_leaves_unset_fields_alone():
+    args = types.SimpleNamespace(
+        remote_host=None, remote_port=None, remote_user=None,
+        remote_pass=None, topic_pattern=None, no_tls=False,
+    )
+    _export_link_env(args)
+    for key in ["REMOTE_MQTT_HOST", "REMOTE_MQTT_PORT", "REMOTE_MQTT_USER",
+                "REMOTE_MQTT_PASS", "LINK_TOPIC_PATTERN", "REMOTE_MQTT_TLS"]:
+        assert key not in os.environ
+
+
+def test_export_link_env_makes_spawned_link_config_reach_resolve_config():
+    """End-to-end regression: values exported here must actually be picked
+    up by link_main.py's own config resolution, matching what a spawned
+    subprocess (fresh argv, args=None) would see."""
+    pytest.importorskip("benchlab.link.link_main")
+    from benchlab.link.link_main import _resolve_config
+
+    args = types.SimpleNamespace(
+        remote_host="cloud.example.com", remote_port=None,
+        remote_user=None, remote_pass=None, topic_pattern=None, no_tls=False,
+    )
+    _export_link_env(args)
+    cfg = _resolve_config(args=None)  # simulates a spawned process's fresh state
+    assert cfg["host"] == "cloud.example.com"
+
+
+def test_check_and_setup_source_direct_warns_when_no_device(caplog):
+    import logging
+    from benchlab.sources import check_and_setup_source
+
+    with patch("benchlab.sources._direct_device_available", return_value=False):
+        with caplog.at_level(logging.WARNING):
+            ready = check_and_setup_source("direct")
+
+    assert ready is True  # still tolerant — tool itself may catch a device later
+    assert any("No BENCHLAB device" in rec.message for rec in caplog.records)
+
+
+def test_check_and_setup_source_direct_no_warning_when_device_present(caplog):
+    import logging
+    from benchlab.sources import check_and_setup_source
+
+    with patch("benchlab.sources._direct_device_available", return_value=True):
+        with caplog.at_level(logging.WARNING):
+            ready = check_and_setup_source("direct")
+
+    assert ready is True
+    assert not any("No BENCHLAB device" in rec.message for rec in caplog.records)
+
+
+def test_check_named_pipe_service_closes_handle_on_write_failure():
+    """Regression: WriteFile/ReadFile raising after CreateFile succeeds must
+    not leak the pipe handle."""
+    from benchlab.sources import check_named_pipe_service
+
+    fake_handle = object()
+    fake_win32file = MagicMock()
+    fake_win32file.CreateFile.return_value = fake_handle
+    fake_win32file.WriteFile.side_effect = RuntimeError("simulated write failure")
+    fake_win32pipe = MagicMock()
+
+    with patch.object(sys, "platform", "win32"), \
+         patch("benchlab.sources._named_pipe_available", return_value=True), \
+         patch.dict(sys.modules, {"win32file": fake_win32file, "win32pipe": fake_win32pipe, "pywintypes": MagicMock()}):
+        result = check_named_pipe_service()
+
+    assert result is False
+    fake_win32file.CloseHandle.assert_called_once_with(fake_handle)

--- a/tests/test_tool_sources.py
+++ b/tests/test_tool_sources.py
@@ -42,11 +42,8 @@ except ImportError:
 import pytest
 
 from benchlab.core.discovery import discover_devices
-from benchlab.main import (
-    CONSUMER_TOOLS,
-    check_and_setup_source,
-    _cleanup_all_services,
-)
+from benchlab.main import CONSUMER_TOOLS, check_and_setup_source
+from benchlab.sources import cleanup_all_services as _cleanup_all_services
 
 # ---------------------------------------------------------------------------
 # Constants


### PR DESCRIPTION
## Summary

Bug sweep of the interactive launcher layer (\`benchlab/main.py\`, \`launcher.py\`, \`menu.py\`, \`tools.py\`, \`sources.py\`), found while reviewing this layer ahead of the planned interactive-UX redesign (#36).

- **\`launcher.py:launch_tools_concurrent\`** (most impactful) — Ctrl+C cleanup called \`os.killpg(os.getpgid(...))\`, which don't exist on Windows at all. Always raised, always silently swallowed by a bare \`except Exception: pass\`. Spawned terminal-window tools (multi-tool launch mode) were never actually terminated on Windows, the primary target platform. Replaced with a new \`_terminate_spawned_process\` helper that branches the same way \`core/process_manager.py\` already does correctly (\`taskkill /T /F\` on Windows, \`killpg\` on POSIX).
- **\`launcher.py:_spawn_tool_in_terminal\`** — Cloud-MQTT \`--remote-host\`/\`-port\`/\`-user\`/\`-pass\`/\`--no-tls\`/\`--topic-pattern\` CLI flags were never exported to env vars, so a \`link\` process spawned in a new terminal (fresh argv, no CLI flags) silently lost that config and fell back to \`.env\`/config-file defaults. Added \`_export_link_env\` in \`main.py\`, mirroring these into the same env vars \`link_main.py\`'s \`_resolve_config\` already reads as a fallback.
- **\`sources.py:check_and_setup_source("direct")\`** — Always returned \`True\` with zero device-reachability check, unlike every other source type. Now warns when pycore reports no BENCHLAB device on any serial port (still returns \`True\` — a device may be connected after this check, before the tool itself opens the port).
- **\`sources.py:check_named_pipe_service\`** — Leaked its pipe handle if \`WriteFile\`/\`ReadFile\` raised after \`CreateFile\` succeeded (no \`finally: CloseHandle\`). Same bug class already fixed in \`config_client.py\`'s \`query_named_pipe\` during the config module sweep (#32).
- **\`menu.py\`/\`tools.py\`** — Each independently mutated \`sys.path\` to import root-level \`bootstrap.py\`. Centralized into \`benchlab/__init__.py\`.
- **\`tests/test_tool_sources.py\`** — Failed to collect entirely: imported a nonexistent \`_cleanup_all_services\` from \`benchlab.main\` (the real name is \`cleanup_all_services\`, defined in \`benchlab.sources\`). Fixed the import.

## Test plan

- [x] \`pytest tests/test_launcher.py -v\` — 10 new tests, no hardware required
- [x] Regression-verified: reverted \`sources.py\`'s two fixes and confirmed 3 of the new tests fail with the original bugs' exact symptoms (no warning logged, handle never closed); restored and confirmed all pass again
- [x] \`tests/test_tool_sources.py\` now collects successfully (was failing at import time before this PR)
- [x] Full non-hardware regression suite (164 tests across config/vu/mqtt/wigidash/hwinfo/graph/tui/restapi/core) passes
- [x] \`pycore-compat.yml\` updated in both \`pinned\` and \`latest\` jobs — import smoke test + new pytest step each
- [ ] CI green on this PR