### PR TITLE
Add Textual-based interactive menu (issue #36)

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -35,8 +35,8 @@ jobs:
         run: >
           python -c "import benchlab.core, benchlab.core.discovery,
           benchlab.core.datasource, benchlab.core.shared_serial,
-          benchlab.main, benchlab.launcher, benchlab.menu, benchlab.tools,
-          benchlab.sources,
+          benchlab.main, benchlab.launcher, benchlab.menu, benchlab.menu_classic,
+          benchlab.tools, benchlab.sources, benchlab.prefs,
           benchlab.config.config_client, benchlab.config.config_manager,
           benchlab.config.diff, benchlab.restapi.telemetry_api,
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export,
@@ -102,6 +102,9 @@ jobs:
 
       - name: Test - launcher bug sweep
         run: pytest tests/test_launcher.py -v
+
+      - name: Test - interactive menu
+        run: pytest tests/test_menu.py -v
 
   latest:
     name: Import + test against latest pycore (PyPI)
@@ -127,8 +130,8 @@ jobs:
         run: >
           python -c "import benchlab.core, benchlab.core.discovery,
           benchlab.core.datasource, benchlab.core.shared_serial,
-          benchlab.main, benchlab.launcher, benchlab.menu, benchlab.tools,
-          benchlab.sources,
+          benchlab.main, benchlab.launcher, benchlab.menu, benchlab.menu_classic,
+          benchlab.tools, benchlab.sources, benchlab.prefs,
           benchlab.config.config_client, benchlab.config.config_manager,
           benchlab.config.diff, benchlab.restapi.telemetry_api,
           benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export,
@@ -194,3 +197,6 @@ jobs:
 
       - name: Test - launcher bug sweep
         run: pytest tests/test_launcher.py -v
+
+      - name: Test - interactive menu
+        run: pytest tests/test_menu.py -v

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.db
 *.config
 *.pid.lock
+.benchlab_prefs.json
 benchlab/vu/generated/
 benchlab/vu/VU-Server/upload/
 

--- a/benchlab/main.py
+++ b/benchlab/main.py
@@ -19,9 +19,17 @@ import traceback
 from .tools import CONSUMER_TOOLS, LAUNCH_PROFILES
 from .sources import check_and_setup_source, cleanup_all_services
 from .launcher import launch_tools_concurrent
-from .menu import interactive_loop
 
 logger = logging.getLogger("benchlab.launcher")
+
+try:
+    from .menu import interactive_loop
+except ImportError as e:
+    # prompt_toolkit isn't installed (or failed to import for some other
+    # reason) — fall back to the plain numbered-input menu rather than
+    # crashing the whole interactive entry point.
+    logger.debug(f"Falling back to classic menu (prompt_toolkit unavailable: {e})")
+    from .menu_classic import interactive_loop
 
 # ──────────────────────────────────────────────────────────────
 # Argument Parser

--- a/benchlab/menu.py
+++ b/benchlab/menu.py
@@ -1,15 +1,27 @@
-"""BENCHLAB PyTools v2 – Interactive Menu System.
+"""BENCHLAB PyTools v2 – Interactive Menu System (Textual).
 
-Implements the three-step interactive menu flow:
-  1. Mode selection (provider / single tool / multi-tool)
-  2. Tool selection
-  3. Data source selection + launch confirmation
+A single full-screen TUI, replacing the old numbered-prompt flow (still
+available as menu_classic.py, used as an automatic fallback if textual
+isn't installed or the app can't start in the current terminal).
+
+Flow:
+  1. Launching straight into the picker screen -- no separate top-level
+     "what would you like to do" prompt first.
+  2. Two tabs: "Run Tool(s)" (Tools checklist stacked above a Data Source
+     radio list, live-filtered to what the selected tool(s) support) and
+     "Data Provider" (run FastAPI or MQTT standalone, no consumer tool).
+  3. Last-used tool(s)/source are pre-selected on open.
+  4. Launch/Start, then remember the choice for next time (tools mode only).
+  5. Any source-specific connection params (broker host, API port, etc.)
+     are prompted for afterward in the terminal, pre-filled from last use
+     -- kept out of the TUI screen itself to avoid duplicating input
+     validation in two places.
 """
 
 import logging
 import os
 import sys
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 from bootstrap import clear_screen
 from .tools import CONSUMER_TOOLS
@@ -22,16 +34,11 @@ from .sources import (
     SERVICE_HTTP_DEFAULT_PORT,
 )
 from .launcher import launch_single_tool, launch_tools_concurrent
+from .prefs import load_prefs, record_launch, get_source_params
 
 logger = logging.getLogger("benchlab.launcher")
 
-
-# ──────────────────────────────────────────────────────────────
-# Banner
-# ──────────────────────────────────────────────────────────────
-
-def print_banner() -> None:
-    print(r"""
+BANNER = r"""
 ██████╗ ███████╗███╗   ██╗ ██████╗██╗  ██╗██╗      █████╗ ██████╗
 ██╔══██╗██╔════╝████╗  ██║██╔════╝██║  ██║██║     ██╔══██╗██╔══██╗
 ██████╔╝█████╗  ██╔██╗ ██║██║     ███████║██║     ███████║██████╔╝
@@ -39,61 +46,501 @@ def print_banner() -> None:
 ██████╔╝███████╗██║ ╚████║╚██████╗██║  ██║███████╗██║  ██║██████╔╝
 ╚═════╝ ╚══════╝╚═╝  ╚═══╝ ╚═════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝
 
-        ██████╗ ██╗   ██╗████████╗ ██████╗  ██████╗ ██╗     ███████╗  
+        ██████╗ ██╗   ██╗████████╗ ██████╗  ██████╗ ██╗     ███████╗
         ██╔══██╗╚██╗ ██╔╝╚══██╔══╝██╔═══██╗██╔═══██╗██║     ██╔════╝
         ██████╔╝ ╚████╔╝    ██║   ██║   ██║██║   ██║██║     ███████╗
         ██╔═══╝   ╚██╔╝     ██║   ██║   ██║██║   ██║██║     ╚════██║
         ██║        ██║      ██║   ╚██████╔╝╚██████╔╝███████╗███████║
         ╚═╝        ╚═╝      ╚═╝    ╚═════╝  ╚═════╝ ╚══════╝╚══════╝
-""")
+"""
+
+SOURCE_LABELS: Dict[str, str] = {
+    "direct": "Direct (serial port)",
+    "fastapi": "FastAPI server (Python)",
+    "fastapi_custom": "FastAPI server (custom URL)",
+    "mqtt": "MQTT (Python, experimental)",
+    "mqtt_custom": "MQTT (custom)",
+    "named_pipe": "BenchLab service - named pipe",
+    "service_http": f"BenchLab service - HTTP API (port {SERVICE_HTTP_DEFAULT_PORT})",
+}
+
+SOURCE_ORDER = ["direct", "fastapi", "fastapi_custom", "mqtt", "mqtt_custom", "named_pipe", "service_http"]
+
+PROVIDER_LABELS: Dict[str, str] = {
+    "fastapi": "FastAPI Server - REST API + WebSocket on port 8000",
+    "mqtt": "MQTT Publisher - publish telemetry to MQTT broker",
+}
+
+
+def print_banner() -> None:
+    print(BANNER)
 
 
 # ──────────────────────────────────────────────────────────────
-# Step 1 – Mode Selection
+# Source compatibility (pure logic, reused by the picker and tests)
 # ──────────────────────────────────────────────────────────────
 
-def show_step1_menu() -> Optional[str]:
-    """Display mode selection. Returns 'provider', 'single', 'multi', or None."""
-    print("What would you like to do?\n")
-    print("  1. Data Provider   - Run FastAPI or MQTT server for other tools")
-    print("  2. Single Tool     - Run one tool with a data source")
-    print("  3. Multi-Tool      - Run multiple tools with shared data (Experimental!)")
-    print()
-    print("  q. Quit")
-    print()
+def _available_sources(is_multi: bool, supported_sources: Optional[List[str]]) -> List[Tuple[str, str]]:
+    """Return (source_id, label) pairs valid for the given tool selection."""
+    is_windows = sys.platform.startswith("win")
 
+    result = []
+    for src in SOURCE_ORDER:
+        if src == "direct" and is_multi:
+            continue
+        if src == "named_pipe" and not is_windows:
+            continue
+        if supported_sources is not None and src not in supported_sources:
+            continue
+        result.append((src, SOURCE_LABELS[src]))
+    return result
+
+
+def _combined_supported_sources(tool_ids: List[str]) -> Optional[List[str]]:
+    """Intersection of supported_sources across selected tools.
+
+    None means "no restriction" (tool doesn't declare supported_sources,
+    or no tools selected yet).
+    """
+    restrictions = [
+        CONSUMER_TOOLS[tid]["supported_sources"]
+        for tid in tool_ids
+        if tid in CONSUMER_TOOLS and CONSUMER_TOOLS[tid].get("supported_sources") is not None
+    ]
+    if not restrictions:
+        return None
+    combined = set(restrictions[0])
+    for r in restrictions[1:]:
+        combined &= set(r)
+    return list(combined)
+
+
+# ──────────────────────────────────────────────────────────────
+# Textual app: "Run Tool(s)" tab + "Data Provider" tab
+# ──────────────────────────────────────────────────────────────
+
+# Result shape returned by the app / _run_picker_screen:
+#   ("tools", tool_ids, source)      -- launch consumer tool(s)
+#   ("provider", provider_type)      -- start a standalone data provider
+#   None                             -- cancelled
+PickerResult = Union[Tuple[str, List[str], str], Tuple[str, str], None]
+
+
+def _build_launcher_app(default_tool_ids: List[str], default_source: Optional[str]):
+    """Construct (but don't run) the Textual LauncherApp. Split out from
+    _run_picker_screen so tests can inspect app state without a real
+    terminal (Textual apps can run headless via App.run_test())."""
+    from textual.app import App, ComposeResult
+    from textual.containers import Vertical
+    from textual.widgets import (
+        Footer, SelectionList, RadioSet, RadioButton, Button, Static, TabbedContent, TabPane,
+    )
+    from textual.widgets.selection_list import Selection
+    from textual.binding import Binding
+
+    class LauncherApp(App):
+        CSS = """
+        Screen {
+            background: $surface;
+        }
+        #banner {
+            width: 100%;
+            content-align: center middle;
+            color: $accent;
+            margin-bottom: 1;
+        }
+        .panel {
+            border: round $primary;
+            padding: 0 1;
+            margin-bottom: 1;
+        }
+        .panel:focus-within {
+            border: round $accent;
+        }
+        #tools-panel {
+            height: 1fr;
+        }
+        #source-panel {
+            height: auto;
+            max-height: 40%;
+        }
+        #provider-panel {
+            height: auto;
+        }
+        #tools-summary, #provider-summary {
+            height: auto;
+            margin-bottom: 1;
+            color: $text-muted;
+        }
+        .launch-btn {
+            width: 100%;
+            margin-top: 1;
+        }
+        .launch-btn.-ready {
+            background: $success;
+        }
+        """
+
+        BINDINGS = [
+            Binding("q", "quit_app", "Quit"),
+            Binding("escape", "quit_app", "Quit"),
+            Binding("ctrl+l", "launch", "Launch"),
+        ]
+
+        TITLE = "BENCHLAB PyTools"
+
+        def __init__(self):
+            super().__init__()
+            self.result: PickerResult = None
+            self._default_tool_ids = default_tool_ids
+            self._default_source = default_source
+
+        def compose(self) -> ComposeResult:
+            yield Static(BANNER, id="banner")
+            with TabbedContent(id="mode-tabs"):
+                with TabPane("Run Tool(s)", id="tab-tools"):
+                    with Vertical(id="tools-panel", classes="panel"):
+                        yield Static("[b]Tools[/b] (space to toggle)")
+                        tool_selections = [
+                            Selection(f"{t['name']} - {t['description']}", tid, tid in self._default_tool_ids)
+                            for tid, t in CONSUMER_TOOLS.items()
+                        ]
+                        yield SelectionList[str](*tool_selections, id="tools")
+                    with Vertical(id="source-panel", classes="panel"):
+                        yield Static("[b]Data Source[/b]")
+                        yield RadioSet(id="sources")
+                    yield Static("", id="tools-summary")
+                    yield Button("Launch", id="launch-btn", variant="primary", classes="launch-btn")
+                with TabPane("Data Provider", id="tab-provider"):
+                    with Vertical(classes="panel", id="provider-panel"):
+                        yield Static("[b]Provider[/b] - runs standalone, no consumer tool")
+                        yield RadioSet(
+                            RadioButton(PROVIDER_LABELS["fastapi"], value=True),
+                            RadioButton(PROVIDER_LABELS["mqtt"]),
+                            id="providers",
+                        )
+                    yield Static("", id="provider-summary")
+                    yield Button("Start Provider", id="provider-btn", variant="primary", classes="launch-btn")
+            yield Footer()
+
+        async def on_mount(self) -> None:
+            await self._refresh_sources()
+            self._update_provider_summary()
+
+        # ── Tools tab ────────────────────────────────────────────
+
+        def _selected_tool_ids(self) -> List[str]:
+            return list(self.query_one("#tools", SelectionList).selected)
+
+        def _current_source_items(self) -> List[Tuple[str, str]]:
+            tool_ids = self._selected_tool_ids()
+            supported = _combined_supported_sources(tool_ids)
+            sources = _available_sources(is_multi=len(tool_ids) > 1, supported_sources=supported)
+            return sources
+
+        async def _refresh_sources(self) -> None:
+            sources = self._current_source_items()
+            radio_set = self.query_one("#sources", RadioSet)
+            self._source_ids = [s for s, _ in sources]
+
+            radio_set._pressed_button = None
+            await radio_set.remove_children()
+            if not sources:
+                await radio_set.mount(RadioButton("(no compatible source)", disabled=True))
+            else:
+                preferred_idx = 0
+                if self._default_source in self._source_ids:
+                    preferred_idx = self._source_ids.index(self._default_source)
+                buttons = [RadioButton(label) for _, label in sources]
+                await radio_set.mount(*buttons)
+                # RadioSet only auto-selects a pre-checked button in its own
+                # one-time _on_mount scan; that doesn't re-run on a dynamic
+                # remount, and setting .value=True just posts an async
+                # Changed message we'd have to await-settle before reading
+                # pressed_index. Simpler and immediate: set the internal
+                # pointer directly, matching what _on_mount itself does.
+                with radio_set.prevent(RadioButton.Changed):
+                    buttons[preferred_idx].value = True
+                radio_set._pressed_button = buttons[preferred_idx]
+            self._update_tools_summary()
+
+        def _current_source_id(self) -> Optional[str]:
+            radio_set = self.query_one("#sources", RadioSet)
+            idx = radio_set.pressed_index
+            if idx is None or idx < 0 or not getattr(self, "_source_ids", None):
+                return None
+            if idx >= len(self._source_ids):
+                return None
+            return self._source_ids[idx]
+
+        def _update_tools_summary(self) -> None:
+            tool_ids = self._selected_tool_ids()
+            source = self._current_source_id()
+            tool_names = ", ".join(CONSUMER_TOOLS[tid]["name"] for tid in tool_ids) or "(none selected)"
+            source_label = SOURCE_LABELS.get(source, "(none)") if source else "(none)"
+            summary = self.query_one("#tools-summary", Static)
+            summary.update(f"Tools: {tool_names}   |   Source: {source_label}")
+
+            btn = self.query_one("#launch-btn", Button)
+            ready = bool(tool_ids and source)
+            btn.disabled = not ready
+            btn.set_class(ready, "-ready")
+
+        async def on_selection_list_selected_changed(self, event) -> None:
+            if event.selection_list.id == "tools":
+                await self._refresh_sources()
+
+        def on_radio_set_changed(self, event) -> None:
+            if event.radio_set.id == "sources":
+                self._update_tools_summary()
+            elif event.radio_set.id == "providers":
+                self._update_provider_summary()
+
+        def on_button_pressed(self, event) -> None:
+            if event.button.id == "launch-btn":
+                self.action_launch()
+            elif event.button.id == "provider-btn":
+                self._start_provider()
+
+        def action_launch(self) -> None:
+            tool_ids = self._selected_tool_ids()
+            source = self._current_source_id()
+            if tool_ids and source:
+                self.result = ("tools", tool_ids, source)
+                self.exit()
+
+        # ── Data Provider tab ───────────────────────────────────
+
+        def _current_provider(self) -> str:
+            idx = self.query_one("#providers", RadioSet).pressed_index
+            return "mqtt" if idx == 1 else "fastapi"
+
+        def _update_provider_summary(self) -> None:
+            provider = self._current_provider()
+            summary = self.query_one("#provider-summary", Static)
+            summary.update(f"Provider: {PROVIDER_LABELS[provider]}")
+
+        def _start_provider(self) -> None:
+            self.result = ("provider", self._current_provider())
+            self.exit()
+
+        # ── Global actions ──────────────────────────────────────
+
+        def action_quit_app(self) -> None:
+            self.result = None
+            self.exit()
+
+    return LauncherApp()
+
+
+def _run_picker_screen(default_tool_ids: List[str], default_source: Optional[str]) -> PickerResult:
+    """Run the full-screen picker. Returns a PickerResult (see above) or
+    None if cancelled.
+
+    Falls back to the sequential prompt-based picker (_sequential_pick) if
+    Textual's app can't start in this terminal.
+    """
+    app = _build_launcher_app(default_tool_ids, default_source)
     try:
-        choice = input("Choice: ").strip().lower()
-        return {"1": "provider", "2": "single", "3": "multi"}.get(choice) or (
-            None if choice in ("q", "quit", "exit") else _invalid("Enter 1, 2, 3, or q.")
-        )
+        app.run()
+    except Exception as e:
+        logger.debug(f"Textual picker failed ({e}); falling back to sequential prompts")
+        return _sequential_pick(default_tool_ids, default_source)
+    except KeyboardInterrupt:
+        return None
+    return app.result
+
+
+# ──────────────────────────────────────────────────────────────
+# Sequential fallback (used if the full-screen app can't run)
+# ──────────────────────────────────────────────────────────────
+
+def _fuzzy_pick(items: List[Tuple[str, str]], title: str, default: Optional[str] = None) -> Optional[str]:
+    """Single-select picker over (value, label) pairs, printing the full
+    option list up front. Accepts a number or enough of a label to match
+    exactly one option.
+    """
+    default_index = next((i for i, (value, _) in enumerate(items, 1) if value == default), None)
+
+    print(f"\n{title}")
+    for i, (_, label) in enumerate(items, 1):
+        marker = " (last used)" if i == default_index else ""
+        print(f"  {i}. {label}{marker}")
+    default_str = str(default_index) if default_index else ""
+    suffix = f" [{default_str}]" if default_str else ""
+    try:
+        answer = input(f"Choice{suffix}: ").strip() or default_str
     except (EOFError, KeyboardInterrupt):
         return None
 
+    if not answer:
+        return None
 
-def _invalid(msg: str) -> None:
-    print(msg)
+    if answer.isdigit():
+        idx = int(answer)
+        if 1 <= idx <= len(items):
+            return items[idx - 1][0]
+        print(f"  No option numbered {idx}.")
+        return None
+
+    labels = [label for _, label in items]
+    matches = [label for label in labels if answer.lower() in label.lower()]
+    if len(matches) == 1:
+        idx = labels.index(matches[0])
+        return items[idx][0]
+
+    print(f"  No unambiguous match for {answer!r}.")
     return None
 
 
+def _multi_pick(items: List[Tuple[str, str]], title: str) -> List[str]:
+    """Comma-separated number list multi-select (plain input())."""
+    print(f"\n{title}")
+    for i, (_, label) in enumerate(items, 1):
+        print(f"  {i}. {label}")
+    print("  Enter numbers separated by commas (e.g. 1,3), or 'all'.")
+    try:
+        answer = input("> ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        return []
+    if not answer:
+        return []
+    if answer == "all":
+        return [value for value, _ in items]
+    selected = []
+    for part in answer.split(","):
+        part = part.strip()
+        if part.isdigit() and 1 <= int(part) <= len(items):
+            selected.append(items[int(part) - 1][0])
+    return selected
+
+
+def _sequential_pick(default_tool_ids: List[str], default_source: Optional[str]) -> PickerResult:
+    """Fallback flow when the full-screen picker can't run: choose tools
+    vs. data-provider mode, then pick accordingly, via sequential prompts."""
+    mode_choice = _fuzzy_pick(
+        [("tools", "Run tool(s) - pick one or more consumer tools and a data source"),
+         ("provider", "Data provider - run FastAPI or MQTT standalone for other processes")],
+        "What would you like to do?",
+    )
+    if mode_choice is None:
+        return None
+
+    if mode_choice == "provider":
+        provider = _fuzzy_pick(list(PROVIDER_LABELS.items()), "Select a data provider:")
+        if provider is None:
+            return None
+        return ("provider", provider)
+
+    tool_values = [(tid, f"{t['name']} - {t['description']}") for tid, t in CONSUMER_TOOLS.items()]
+
+    print("\n=== Select Tool(s) ===")
+    try:
+        sub_mode = input("Single tool or multiple? (s/m) [s]: ").strip().lower() or "s"
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+    if sub_mode.startswith("m"):
+        tool_ids = _multi_pick(tool_values, "Select Tools")
+        if not tool_ids:
+            print("  No tools selected.")
+            return None
+    else:
+        tool_id = _fuzzy_pick(tool_values, "Select a tool:", default=default_tool_ids[0] if default_tool_ids else None)
+        if tool_id is None:
+            return None
+        tool_ids = [tool_id]
+
+    supported = _combined_supported_sources(tool_ids)
+    sources = _available_sources(is_multi=len(tool_ids) > 1, supported_sources=supported)
+    if not sources:
+        print("  No compatible data source available for this selection.")
+        return None
+
+    valid_defaults = [s for s, _ in sources]
+    default = default_source if default_source in valid_defaults else None
+    source = _fuzzy_pick(sources, "Select a data source:", default=default)
+    if source is None:
+        return None
+
+    return ("tools", tool_ids, source)
+
+
 # ──────────────────────────────────────────────────────────────
-# Step 2a – Data Provider
+# Source connection params (pre-filled from remembered prefs)
 # ──────────────────────────────────────────────────────────────
 
-def step2_data_provider() -> None:
-    """Select and start a standalone data provider."""
-    print()
-    print("=== Data Provider ===")
-    print("1. FastAPI Server  - REST API + WebSocket on port 8000")
-    print("2. MQTT Publisher  - Publish telemetry to MQTT broker")
-    print()
+def _prompt_default(label: str, default: str) -> str:
+    try:
+        val = input(f"  {label} [{default}]: ").strip()
+    except (EOFError, KeyboardInterrupt):
+        return default
+    return val or default
 
-    choice = input("Choice [1-2]: ").strip()
 
-    if choice == "1":
-        port_input = input("  Port [8000]: ").strip()
+_last_source_params: Dict[str, Dict] = {}
+
+
+def _setup_source(source_type: str) -> bool:
+    """Prompt for any source-specific params, then check/start the source."""
+    remembered = get_source_params(source_type)
+    setup_kwargs: Dict = {}
+
+    if source_type == "fastapi":
+        port = int(remembered.get("port", os.environ.get("API_PORT", "8000")))
+        setup_kwargs = {"port": port}
+
+    elif source_type == "fastapi_custom":
+        host = _prompt_default("Host/IP", remembered.get("host", "127.0.0.1"))
+        port = _prompt_default("Port", str(remembered.get("port", 8000)))
         try:
-            port = int(port_input) if port_input else 8000
+            port = int(port)
+        except ValueError:
+            print("  Invalid port number.")
+            return False
+        base_url = f"http://{host}:{port}"
+        setup_kwargs = {"base_url": base_url}
+        os.environ["BENCHLAB_FASTAPI_CUSTOM_URL"] = base_url
+        remembered = {"host": host, "port": port}
+
+    elif source_type == "mqtt":
+        broker = os.environ.get("MQTT_BROKER", remembered.get("broker", "localhost"))
+        mqtt_port = int(os.environ.get("MQTT_PORT", remembered.get("mqtt_port", 1883)))
+        setup_kwargs = {"broker": broker, "mqtt_port": mqtt_port}
+
+    elif source_type == "mqtt_custom":
+        broker = _prompt_default("Broker host", remembered.get("broker", "localhost"))
+        mqtt_port = _prompt_default("Broker port", str(remembered.get("mqtt_port", 1883)))
+        try:
+            mqtt_port = int(mqtt_port)
+        except ValueError:
+            print("  Invalid port number.")
+            return False
+        setup_kwargs = {"broker": broker, "mqtt_port": mqtt_port}
+        remembered = {"broker": broker, "mqtt_port": mqtt_port}
+
+    elif source_type == "service_http":
+        import urllib.parse
+        svc_url = os.environ.get(
+            "BENCHLAB_SERVICE_URL", f"http://localhost:{SERVICE_HTTP_DEFAULT_PORT}"
+        )
+        parsed = urllib.parse.urlparse(svc_url)
+        setup_kwargs = {"host": parsed.hostname or "localhost", "port": parsed.port or SERVICE_HTTP_DEFAULT_PORT}
+
+    ready = check_and_setup_source(source_type, **setup_kwargs)
+    _last_source_params[source_type] = remembered
+    return ready
+
+
+# ──────────────────────────────────────────────────────────────
+# Data Provider Mode (standalone FastAPI/MQTT, no consumer tool)
+# ──────────────────────────────────────────────────────────────
+
+def _run_data_provider(provider: str) -> None:
+    if provider == "fastapi":
+        port = _prompt_default("Port", "8000")
+        try:
+            port = int(port)
         except ValueError:
             print("  Invalid port number.")
             return
@@ -104,11 +551,11 @@ def step2_data_provider() -> None:
         print("FastAPI server running. Press Ctrl+C to stop the provider.")
         input("  (Press Enter to return to menu after verifying...) ")
 
-    elif choice == "2":
-        host = input("  Broker host [localhost]: ").strip() or "localhost"
-        port_input = input("  Broker port [1883]: ").strip()
+    elif provider == "mqtt":
+        host = _prompt_default("Broker host", "localhost")
+        port = _prompt_default("Broker port", "1883")
         try:
-            port = int(port_input) if port_input else 1883
+            port = int(port)
         except ValueError:
             print("  Invalid port number.")
             return
@@ -126,228 +573,37 @@ def step2_data_provider() -> None:
         logger.info("Press Ctrl+C to stop the provider.")
         input("  (Press Enter to return to menu after verifying...) ")
 
-    else:
-        logger.error("Invalid choice in data provider selection.")
-
 
 # ──────────────────────────────────────────────────────────────
-# Step 2b – Single Tool
+# Top-level flow
 # ──────────────────────────────────────────────────────────────
 
-def step2_single_tool() -> None:
-    """Select one tool and proceed to source selection."""
-    print()
-    print("=== Select Tool ===")
-    consumer_list = list(CONSUMER_TOOLS.items())
-    for i, (_, t) in enumerate(consumer_list, 1):
-        print(f"  {i}. {t['name']} - {t['description']}")
-    print()
+def _launch(tool_ids: List[str], source: str) -> None:
+    tool_names = [CONSUMER_TOOLS[tid]["name"] for tid in tool_ids]
 
-    choice = input("Tool number: ").strip()
-    try:
-        idx = int(choice) - 1
-        if not (0 <= idx < len(consumer_list)):
-            print("  Invalid selection.")
-            return
-        tool_id, tool_info = consumer_list[idx]
-    except (ValueError, IndexError):
-        print("  Invalid selection.")
+    _last_source_params.clear()
+    if not _setup_source(source):
+        print(f"\n  Could not set up '{source}' data source.")
+        if source in ("named_pipe", "service_http"):
+            print("  Start the BenchLab Windows service (BL_Service.exe) and try again.")
         return
 
-    step3_select_source(tool_ids=[tool_id], tool_names=[tool_info["name"]])
-
-
-# ──────────────────────────────────────────────────────────────
-# Step 2c – Multi-Tool
-# ──────────────────────────────────────────────────────────────
-
-def step2_multi_tool() -> None:
-    """Select multiple tools and proceed to source selection. (Experimental!)"""
-    print()
-    print("=== Select Tools ===")
-    print("Enter tool numbers separated by commas (e.g., 1,3,5)")
-    print("Or 'all' to select all.")
-
-    consumer_list = list(CONSUMER_TOOLS.items())
-    for i, (_, t) in enumerate(consumer_list, 1):
-        print(f"  {i}. {t['name']} - {t['description']}")
-    print()
-
-    choice = input("Tools: ").strip().lower()
-    if not choice:
-        print("  No tools selected.")
-        return
-
-    if choice == "all":
-        selected = list(consumer_list)
-    else:
-        selected = []
-        for part in choice.split(","):
-            try:
-                idx = int(part.strip()) - 1
-                if 0 <= idx < len(consumer_list):
-                    selected.append(consumer_list[idx])
-            except ValueError:
-                pass
-
-    if not selected:
-        print("  No valid tools selected.")
-        return
-
-    step3_select_source(
-        tool_ids=[tid for tid, _ in selected],
-        tool_names=[t["name"] for _, t in selected],
-    )
-
-
-# ──────────────────────────────────────────────────────────────
-# Step 3 – Source Selection & Launch
-# ──────────────────────────────────────────────────────────────
-
-def _build_source_menu(is_multi: bool, supported_sources: Optional[List[str]] = None) -> dict:
-    """Build the source selection menu.
-
-    Args:
-        is_multi: Whether multiple tools are being launched
-        supported_sources: Optional list of source types to include (e.g., ["direct", "named_pipe"])
-                          If None, all sources are shown.
-
-    Returns a dict mapping menu key → (label, source_type).
-    All sources are always listed unless filtered by supported_sources.
-    OS-unsupported ones get a note.
-    """
-    is_windows = sys.platform.startswith("win")
-    os_name = "Windows" if is_windows else ("macOS" if sys.platform == "darwin" else "Linux")
-
-    # Build all possible sources
-    all_sources = []
-    
-    if not is_multi:
-        all_sources.append(("Direct (serial port)", "direct"))
-    
-    all_sources.append(("FastAPI server (Python)", "fastapi"))
-    all_sources.append(("FastAPI server (custom URL)", "fastapi_custom"))
-    all_sources.append(("MQTT (Python, experimental)", "mqtt"))
-    all_sources.append(("MQTT (custom)", "mqtt_custom"))
-    
-    pipe_note = "" if is_windows else f"  (not available on {os_name})"
-    all_sources.append((f"BenchLab service - named pipe{pipe_note}", "named_pipe"))
-    all_sources.append((f"BenchLab service - HTTP API (port {SERVICE_HTTP_DEFAULT_PORT})", "service_http"))
-    
-    # Filter by supported_sources if provided
-    if supported_sources is not None:
-        all_sources = [(label, src_type) for label, src_type in all_sources 
-                       if src_type in supported_sources]
-    
-    # Build numbered menu
-    sources = {}
-    for key, (label, src_type) in enumerate(all_sources, 1):
-        sources[str(key)] = (label, src_type)
-    
-    return sources
-
-
-def step3_select_source(tool_ids: List[str], tool_names: List[str]) -> None:
-    """Select data source, verify/start it, confirm, then launch tools."""
-    is_multi = len(tool_ids) > 1
-    print()
-    print("=== Data Source ===")
-
-    if is_multi:
-        print(f"Tools: {', '.join(tool_names)}")
-        print("  Note: Direct mode is not available for multi-tool")
-        print("  because the serial port can only be used by one process.")
-    else:
-        print(f"Tool: {tool_names[0]}")
-
-    print()
-
-    # Get supported sources for single tool (if specified)
-    supported_sources = None
-    if not is_multi and len(tool_ids) == 1:
-        tool_info = CONSUMER_TOOLS.get(tool_ids[0])
-        if tool_info:
-            supported_sources = tool_info.get("supported_sources")
-
-    sources = _build_source_menu(is_multi, supported_sources)
-
-    for key, (label, _) in sorted(sources.items()):
-        print(f"  {key}. {label}")
-
-    print()
-    default_key = min(sources.keys())
-    choice = input(f"Choice (default: {default_key}): ").strip() or default_key
-
-    if choice not in sources:
-        print("  Invalid choice.")
-        return
-
-    label, source_type = sources[choice]
-
-    logger.info(f"Setting up {source_type} data source...")
-
-    # Build kwargs for check_and_setup_source
-    setup_kwargs: dict = {}
-    if source_type == "fastapi":
-        port = int(os.environ.get("API_PORT", "8000"))
-        setup_kwargs = {"port": port}
-    elif source_type == "fastapi_custom":
-        # Prompt for custom FastAPI server URL
-        host = input("  Host/IP [127.0.0.1]: ").strip() or "127.0.0.1"
-        port_input = input("  Port [8000]: ").strip()
-        try:
-            port = int(port_input) if port_input else 8000
-        except ValueError:
-            print("  Invalid port number.")
-            return
-        base_url = f"http://{host}:{port}"
-        setup_kwargs = {"base_url": base_url}
-        # Store for later use by datasource manager
-        os.environ["BENCHLAB_FASTAPI_CUSTOM_URL"] = base_url
-        print(f"  → Using FastAPI server at {base_url}")
-    elif source_type == "mqtt":
-        broker = os.environ.get("MQTT_BROKER", "localhost")
-        mqtt_port = int(os.environ.get("MQTT_PORT", "1883"))
-        setup_kwargs = {"broker": broker, "mqtt_port": mqtt_port}
-    elif source_type == "mqtt_custom":
-        # Prompt for custom MQTT broker
-        broker = input("  Broker host [localhost]: ").strip() or "localhost"
-        port_input = input("  Broker port [1883]: ").strip()
-        try:
-            mqtt_port = int(port_input) if port_input else 1883
-        except ValueError:
-            print("  Invalid port number.")
-            return
-        setup_kwargs = {"broker": broker, "mqtt_port": mqtt_port}
-        print(f"  → Using MQTT broker at {broker}:{mqtt_port}")
-    elif source_type == "service_http":
-        import urllib.parse
-        svc_url = os.environ.get("BENCHLAB_SERVICE_URL", f"http://localhost:{SERVICE_HTTP_DEFAULT_PORT}")
-        parsed = urllib.parse.urlparse(svc_url)
-        setup_kwargs = {"host": parsed.hostname or "localhost", "port": parsed.port or SERVICE_HTTP_DEFAULT_PORT}
-
-    source_ready = check_and_setup_source(source_type, **setup_kwargs)
-
-    if not source_ready:
-        print(f"\n  ✗ Could not set up {source_type} data source.")
-        if source_type in ("named_pipe", "service_http"):
-            print("  → Start the BenchLab Windows service (BL_Service.exe) and try again.")
-        return
-
-    print()
-    print("=== Launch Summary ===")
+    print("\n=== Launch Summary ===")
     print(f"Tools: {', '.join(tool_names)}")
-    print(f"Data source: {source_type}")
-    print()
-
-    if input("Launch? (Y/n): ").strip().lower() in ("n", "no"):
-        print("Aborted.")
+    print(f"Data source: {source}")
+    try:
+        if input("Launch? (Y/n): ").strip().lower() in ("n", "no"):
+            print("Aborted.")
+            return
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted.")
         return
 
-    os.environ["BENCHLAB_DATA_SOURCE"] = source_type
+    os.environ["BENCHLAB_DATA_SOURCE"] = source
+    record_launch(tool_ids, source, _last_source_params.get(source))
 
     try:
-        if is_multi:
+        if len(tool_ids) > 1:
             launch_tools_concurrent(tool_ids)
         else:
             launch_single_tool(tool_ids[0])
@@ -357,32 +613,30 @@ def step3_select_source(tool_ids: List[str], tool_names: List[str]) -> None:
         cleanup_all_services()
 
 
-# ──────────────────────────────────────────────────────────────
-# Main Interactive Loop
-# ──────────────────────────────────────────────────────────────
-
 def interactive_loop() -> None:
-    """Drive the top-level interactive menu until the user quits."""
-    clear_screen()
-    print_banner()
-
+    """Drive the interactive menu until the user quits."""
     while True:
         try:
-            mode = show_step1_menu()
-            if mode is None:
+            prefs = load_prefs()
+            default_tool_ids = [tid for tid in (prefs.get("last_tool_ids") or []) if tid in CONSUMER_TOOLS]
+            default_source = prefs.get("last_source")
+
+            picked = _run_picker_screen(default_tool_ids, default_source)
+            clear_screen()
+
+            if picked is None:
                 print("Goodbye!")
                 cleanup_all_services()
                 return
 
-            if mode == "provider":
-                step2_data_provider()
-            elif mode == "single":
-                step2_single_tool()
-            elif mode == "multi":
-                step2_multi_tool()
+            if picked[0] == "provider":
+                _, provider = picked
+                _run_data_provider(provider)
+            elif picked[0] == "tools":
+                _, tool_ids, source = picked
+                _launch(tool_ids, source)
 
             input("\n  Press Enter to continue... ")
-            clear_screen()
 
         except (EOFError, KeyboardInterrupt):
             print("Goodbye!")

--- a/benchlab/menu_classic.py
+++ b/benchlab/menu_classic.py
@@ -1,0 +1,390 @@
+"""BENCHLAB PyTools v2 – Interactive Menu System.
+
+Implements the three-step interactive menu flow:
+  1. Mode selection (provider / single tool / multi-tool)
+  2. Tool selection
+  3. Data source selection + launch confirmation
+"""
+
+import logging
+import os
+import sys
+from typing import List, Optional
+
+from bootstrap import clear_screen
+from .tools import CONSUMER_TOOLS
+from .sources import (
+    check_and_setup_source,
+    check_mqtt_running,
+    start_mqtt_broker,
+    start_mqtt_source,
+    cleanup_all_services,
+    SERVICE_HTTP_DEFAULT_PORT,
+)
+from .launcher import launch_single_tool, launch_tools_concurrent
+
+logger = logging.getLogger("benchlab.launcher")
+
+
+# ──────────────────────────────────────────────────────────────
+# Banner
+# ──────────────────────────────────────────────────────────────
+
+def print_banner() -> None:
+    print(r"""
+██████╗ ███████╗███╗   ██╗ ██████╗██╗  ██╗██╗      █████╗ ██████╗
+██╔══██╗██╔════╝████╗  ██║██╔════╝██║  ██║██║     ██╔══██╗██╔══██╗
+██████╔╝█████╗  ██╔██╗ ██║██║     ███████║██║     ███████║██████╔╝
+██╔══██╗██╔══╝  ██║╚██╗██║██║     ██╔══██║██║     ██╔══██║██╔══██╗
+██████╔╝███████╗██║ ╚████║╚██████╗██║  ██║███████╗██║  ██║██████╔╝
+╚═════╝ ╚══════╝╚═╝  ╚═══╝ ╚═════╝╚═╝  ╚═╝╚══════╝╚═╝  ╚═╝╚═════╝
+
+        ██████╗ ██╗   ██╗████████╗ ██████╗  ██████╗ ██╗     ███████╗  
+        ██╔══██╗╚██╗ ██╔╝╚══██╔══╝██╔═══██╗██╔═══██╗██║     ██╔════╝
+        ██████╔╝ ╚████╔╝    ██║   ██║   ██║██║   ██║██║     ███████╗
+        ██╔═══╝   ╚██╔╝     ██║   ██║   ██║██║   ██║██║     ╚════██║
+        ██║        ██║      ██║   ╚██████╔╝╚██████╔╝███████╗███████║
+        ╚═╝        ╚═╝      ╚═╝    ╚═════╝  ╚═════╝ ╚══════╝╚══════╝
+""")
+
+
+# ──────────────────────────────────────────────────────────────
+# Step 1 – Mode Selection
+# ──────────────────────────────────────────────────────────────
+
+def show_step1_menu() -> Optional[str]:
+    """Display mode selection. Returns 'provider', 'single', 'multi', or None."""
+    print("What would you like to do?\n")
+    print("  1. Data Provider   - Run FastAPI or MQTT server for other tools")
+    print("  2. Single Tool     - Run one tool with a data source")
+    print("  3. Multi-Tool      - Run multiple tools with shared data (Experimental!)")
+    print()
+    print("  q. Quit")
+    print()
+
+    try:
+        choice = input("Choice: ").strip().lower()
+        return {"1": "provider", "2": "single", "3": "multi"}.get(choice) or (
+            None if choice in ("q", "quit", "exit") else _invalid("Enter 1, 2, 3, or q.")
+        )
+    except (EOFError, KeyboardInterrupt):
+        return None
+
+
+def _invalid(msg: str) -> None:
+    print(msg)
+    return None
+
+
+# ──────────────────────────────────────────────────────────────
+# Step 2a – Data Provider
+# ──────────────────────────────────────────────────────────────
+
+def step2_data_provider() -> None:
+    """Select and start a standalone data provider."""
+    print()
+    print("=== Data Provider ===")
+    print("1. FastAPI Server  - REST API + WebSocket on port 8000")
+    print("2. MQTT Publisher  - Publish telemetry to MQTT broker")
+    print()
+
+    choice = input("Choice [1-2]: ").strip()
+
+    if choice == "1":
+        port_input = input("  Port [8000]: ").strip()
+        try:
+            port = int(port_input) if port_input else 8000
+        except ValueError:
+            print("  Invalid port number.")
+            return
+        os.environ["API_PORT"] = str(port)
+        if not check_and_setup_source("fastapi", port=port):
+            logger.error("Could not start FastAPI server.")
+            return
+        print("FastAPI server running. Press Ctrl+C to stop the provider.")
+        input("  (Press Enter to return to menu after verifying...) ")
+
+    elif choice == "2":
+        host = input("  Broker host [localhost]: ").strip() or "localhost"
+        port_input = input("  Broker port [1883]: ").strip()
+        try:
+            port = int(port_input) if port_input else 1883
+        except ValueError:
+            print("  Invalid port number.")
+            return
+        if not check_mqtt_running(host, port):
+            logger.warning(f"No MQTT broker at {host}:{port}")
+            logger.info("Starting embedded broker...")
+            if not start_mqtt_broker(port):
+                logger.error("Could not start MQTT broker.")
+                return
+        else:
+            logger.info(f"MQTT broker available at {host}:{port}")
+        os.environ["MQTT_BROKER"] = host
+        os.environ["MQTT_PORT"] = str(port)
+        start_mqtt_source(host, port)
+        logger.info("Press Ctrl+C to stop the provider.")
+        input("  (Press Enter to return to menu after verifying...) ")
+
+    else:
+        logger.error("Invalid choice in data provider selection.")
+
+
+# ──────────────────────────────────────────────────────────────
+# Step 2b – Single Tool
+# ──────────────────────────────────────────────────────────────
+
+def step2_single_tool() -> None:
+    """Select one tool and proceed to source selection."""
+    print()
+    print("=== Select Tool ===")
+    consumer_list = list(CONSUMER_TOOLS.items())
+    for i, (_, t) in enumerate(consumer_list, 1):
+        print(f"  {i}. {t['name']} - {t['description']}")
+    print()
+
+    choice = input("Tool number: ").strip()
+    try:
+        idx = int(choice) - 1
+        if not (0 <= idx < len(consumer_list)):
+            print("  Invalid selection.")
+            return
+        tool_id, tool_info = consumer_list[idx]
+    except (ValueError, IndexError):
+        print("  Invalid selection.")
+        return
+
+    step3_select_source(tool_ids=[tool_id], tool_names=[tool_info["name"]])
+
+
+# ──────────────────────────────────────────────────────────────
+# Step 2c – Multi-Tool
+# ──────────────────────────────────────────────────────────────
+
+def step2_multi_tool() -> None:
+    """Select multiple tools and proceed to source selection. (Experimental!)"""
+    print()
+    print("=== Select Tools ===")
+    print("Enter tool numbers separated by commas (e.g., 1,3,5)")
+    print("Or 'all' to select all.")
+
+    consumer_list = list(CONSUMER_TOOLS.items())
+    for i, (_, t) in enumerate(consumer_list, 1):
+        print(f"  {i}. {t['name']} - {t['description']}")
+    print()
+
+    choice = input("Tools: ").strip().lower()
+    if not choice:
+        print("  No tools selected.")
+        return
+
+    if choice == "all":
+        selected = list(consumer_list)
+    else:
+        selected = []
+        for part in choice.split(","):
+            try:
+                idx = int(part.strip()) - 1
+                if 0 <= idx < len(consumer_list):
+                    selected.append(consumer_list[idx])
+            except ValueError:
+                pass
+
+    if not selected:
+        print("  No valid tools selected.")
+        return
+
+    step3_select_source(
+        tool_ids=[tid for tid, _ in selected],
+        tool_names=[t["name"] for _, t in selected],
+    )
+
+
+# ──────────────────────────────────────────────────────────────
+# Step 3 – Source Selection & Launch
+# ──────────────────────────────────────────────────────────────
+
+def _build_source_menu(is_multi: bool, supported_sources: Optional[List[str]] = None) -> dict:
+    """Build the source selection menu.
+
+    Args:
+        is_multi: Whether multiple tools are being launched
+        supported_sources: Optional list of source types to include (e.g., ["direct", "named_pipe"])
+                          If None, all sources are shown.
+
+    Returns a dict mapping menu key → (label, source_type).
+    All sources are always listed unless filtered by supported_sources.
+    OS-unsupported ones get a note.
+    """
+    is_windows = sys.platform.startswith("win")
+    os_name = "Windows" if is_windows else ("macOS" if sys.platform == "darwin" else "Linux")
+
+    # Build all possible sources
+    all_sources = []
+    
+    if not is_multi:
+        all_sources.append(("Direct (serial port)", "direct"))
+    
+    all_sources.append(("FastAPI server (Python)", "fastapi"))
+    all_sources.append(("FastAPI server (custom URL)", "fastapi_custom"))
+    all_sources.append(("MQTT (Python, experimental)", "mqtt"))
+    all_sources.append(("MQTT (custom)", "mqtt_custom"))
+    
+    pipe_note = "" if is_windows else f"  (not available on {os_name})"
+    all_sources.append((f"BenchLab service - named pipe{pipe_note}", "named_pipe"))
+    all_sources.append((f"BenchLab service - HTTP API (port {SERVICE_HTTP_DEFAULT_PORT})", "service_http"))
+    
+    # Filter by supported_sources if provided
+    if supported_sources is not None:
+        all_sources = [(label, src_type) for label, src_type in all_sources 
+                       if src_type in supported_sources]
+    
+    # Build numbered menu
+    sources = {}
+    for key, (label, src_type) in enumerate(all_sources, 1):
+        sources[str(key)] = (label, src_type)
+    
+    return sources
+
+
+def step3_select_source(tool_ids: List[str], tool_names: List[str]) -> None:
+    """Select data source, verify/start it, confirm, then launch tools."""
+    is_multi = len(tool_ids) > 1
+    print()
+    print("=== Data Source ===")
+
+    if is_multi:
+        print(f"Tools: {', '.join(tool_names)}")
+        print("  Note: Direct mode is not available for multi-tool")
+        print("  because the serial port can only be used by one process.")
+    else:
+        print(f"Tool: {tool_names[0]}")
+
+    print()
+
+    # Get supported sources for single tool (if specified)
+    supported_sources = None
+    if not is_multi and len(tool_ids) == 1:
+        tool_info = CONSUMER_TOOLS.get(tool_ids[0])
+        if tool_info:
+            supported_sources = tool_info.get("supported_sources")
+
+    sources = _build_source_menu(is_multi, supported_sources)
+
+    for key, (label, _) in sorted(sources.items()):
+        print(f"  {key}. {label}")
+
+    print()
+    default_key = min(sources.keys())
+    choice = input(f"Choice (default: {default_key}): ").strip() or default_key
+
+    if choice not in sources:
+        print("  Invalid choice.")
+        return
+
+    label, source_type = sources[choice]
+
+    logger.info(f"Setting up {source_type} data source...")
+
+    # Build kwargs for check_and_setup_source
+    setup_kwargs: dict = {}
+    if source_type == "fastapi":
+        port = int(os.environ.get("API_PORT", "8000"))
+        setup_kwargs = {"port": port}
+    elif source_type == "fastapi_custom":
+        # Prompt for custom FastAPI server URL
+        host = input("  Host/IP [127.0.0.1]: ").strip() or "127.0.0.1"
+        port_input = input("  Port [8000]: ").strip()
+        try:
+            port = int(port_input) if port_input else 8000
+        except ValueError:
+            print("  Invalid port number.")
+            return
+        base_url = f"http://{host}:{port}"
+        setup_kwargs = {"base_url": base_url}
+        # Store for later use by datasource manager
+        os.environ["BENCHLAB_FASTAPI_CUSTOM_URL"] = base_url
+        print(f"  → Using FastAPI server at {base_url}")
+    elif source_type == "mqtt":
+        broker = os.environ.get("MQTT_BROKER", "localhost")
+        mqtt_port = int(os.environ.get("MQTT_PORT", "1883"))
+        setup_kwargs = {"broker": broker, "mqtt_port": mqtt_port}
+    elif source_type == "mqtt_custom":
+        # Prompt for custom MQTT broker
+        broker = input("  Broker host [localhost]: ").strip() or "localhost"
+        port_input = input("  Broker port [1883]: ").strip()
+        try:
+            mqtt_port = int(port_input) if port_input else 1883
+        except ValueError:
+            print("  Invalid port number.")
+            return
+        setup_kwargs = {"broker": broker, "mqtt_port": mqtt_port}
+        print(f"  → Using MQTT broker at {broker}:{mqtt_port}")
+    elif source_type == "service_http":
+        import urllib.parse
+        svc_url = os.environ.get("BENCHLAB_SERVICE_URL", f"http://localhost:{SERVICE_HTTP_DEFAULT_PORT}")
+        parsed = urllib.parse.urlparse(svc_url)
+        setup_kwargs = {"host": parsed.hostname or "localhost", "port": parsed.port or SERVICE_HTTP_DEFAULT_PORT}
+
+    source_ready = check_and_setup_source(source_type, **setup_kwargs)
+
+    if not source_ready:
+        print(f"\n  ✗ Could not set up {source_type} data source.")
+        if source_type in ("named_pipe", "service_http"):
+            print("  → Start the BenchLab Windows service (BL_Service.exe) and try again.")
+        return
+
+    print()
+    print("=== Launch Summary ===")
+    print(f"Tools: {', '.join(tool_names)}")
+    print(f"Data source: {source_type}")
+    print()
+
+    if input("Launch? (Y/n): ").strip().lower() in ("n", "no"):
+        print("Aborted.")
+        return
+
+    os.environ["BENCHLAB_DATA_SOURCE"] = source_type
+
+    try:
+        if is_multi:
+            launch_tools_concurrent(tool_ids)
+        else:
+            launch_single_tool(tool_ids[0])
+    except KeyboardInterrupt:
+        print("\n  Interrupted.")
+    finally:
+        cleanup_all_services()
+
+
+# ──────────────────────────────────────────────────────────────
+# Main Interactive Loop
+# ──────────────────────────────────────────────────────────────
+
+def interactive_loop() -> None:
+    """Drive the top-level interactive menu until the user quits."""
+    clear_screen()
+    print_banner()
+
+    while True:
+        try:
+            mode = show_step1_menu()
+            if mode is None:
+                print("Goodbye!")
+                cleanup_all_services()
+                return
+
+            if mode == "provider":
+                step2_data_provider()
+            elif mode == "single":
+                step2_single_tool()
+            elif mode == "multi":
+                step2_multi_tool()
+
+            input("\n  Press Enter to continue... ")
+            clear_screen()
+
+        except (EOFError, KeyboardInterrupt):
+            print("Goodbye!")
+            cleanup_all_services()
+            return

--- a/benchlab/prefs.py
+++ b/benchlab/prefs.py
@@ -1,0 +1,64 @@
+"""BENCHLAB PyTools v2 – Interactive Menu Preferences.
+
+Persists the last-used tool(s)/source/connection params between runs of
+the interactive menu, so a repeat launch can default to "press Enter to
+repeat" instead of re-asking everything from scratch.
+
+Stored as plain JSON in the repo root (gitignored) — not meant to be
+portable or synced, just a local convenience.
+"""
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("benchlab.launcher")
+
+PREFS_FILE = Path(__file__).resolve().parent.parent / ".benchlab_prefs.json"
+
+_DEFAULTS: Dict[str, Any] = {
+    "last_tool_ids": [],
+    "last_source": None,
+    "source_params": {},   # source_type -> {param: value}
+}
+
+
+def load_prefs() -> Dict[str, Any]:
+    """Load persisted menu preferences, tolerating a missing/corrupt file."""
+    if not PREFS_FILE.exists():
+        return dict(_DEFAULTS)
+    try:
+        with open(PREFS_FILE, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        merged = dict(_DEFAULTS)
+        merged.update(data)
+        return merged
+    except (OSError, json.JSONDecodeError) as e:
+        logger.debug(f"Could not load menu preferences ({e}) — starting fresh")
+        return dict(_DEFAULTS)
+
+
+def save_prefs(prefs: Dict[str, Any]) -> None:
+    """Persist menu preferences. Failure to save is non-fatal."""
+    try:
+        with open(PREFS_FILE, "w", encoding="utf-8") as f:
+            json.dump(prefs, f, indent=2)
+    except OSError as e:
+        logger.debug(f"Could not save menu preferences: {e}")
+
+
+def record_launch(tool_ids: List[str], source: str, source_params: Optional[Dict[str, Any]] = None) -> None:
+    """Record a successful tool/source selection for next run's defaults."""
+    prefs = load_prefs()
+    prefs["last_tool_ids"] = list(tool_ids)
+    prefs["last_source"] = source
+    if source_params:
+        prefs.setdefault("source_params", {})[source] = source_params
+    save_prefs(prefs)
+
+
+def get_source_params(source: str) -> Dict[str, Any]:
+    """Return remembered connection params for a given source type, if any."""
+    prefs = load_prefs()
+    return prefs.get("source_params", {}).get(source, {})

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # Core dependencies with version pins (DEP-1)
 packaging>=23.0,<26.0
 python-dotenv>=1.0.0,<2.0
+textual>=0.60,<9.0
 
 # BENCHLAB Serial Handler
 benchlab-pycore>=0.5.1

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,568 @@
+"""Non-hardware regression tests for the interactive menu redesign (issue #36).
+
+Covers:
+- prefs.py's load/save/record round-trip, and tolerance of a missing or
+  corrupt prefs file.
+- menu.py's pure-logic helpers (_available_sources filtering) that don't
+  require a real TTY/prompt_toolkit interaction.
+- main.py falls back to menu_classic.interactive_loop when benchlab.menu
+  fails to import (e.g. prompt_toolkit not installed).
+"""
+
+import importlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# prefs.py
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def prefs_module(tmp_path, monkeypatch):
+    import benchlab.prefs as prefs
+    monkeypatch.setattr(prefs, "PREFS_FILE", tmp_path / "prefs.json")
+    return prefs
+
+
+def test_load_prefs_defaults_when_file_missing(prefs_module):
+    prefs = prefs_module.load_prefs()
+    assert prefs == {"last_tool_ids": [], "last_source": None, "source_params": {}}
+
+
+def test_load_prefs_tolerates_corrupt_json(prefs_module):
+    prefs_module.PREFS_FILE.write_text("{not valid json", encoding="utf-8")
+    prefs = prefs_module.load_prefs()
+    assert prefs["last_tool_ids"] == []
+
+
+def test_record_launch_round_trips(prefs_module):
+    prefs_module.record_launch(["tui", "vu"], "fastapi", {"port": 8000})
+    loaded = prefs_module.load_prefs()
+    assert loaded["last_tool_ids"] == ["tui", "vu"]
+    assert loaded["last_source"] == "fastapi"
+    assert loaded["source_params"]["fastapi"] == {"port": 8000}
+
+
+def test_get_source_params_returns_empty_for_unset_source(prefs_module):
+    prefs_module.record_launch(["tui"], "fastapi", {"port": 8000})
+    assert prefs_module.get_source_params("mqtt") == {}
+
+
+def test_record_launch_without_params_does_not_clear_prior_ones(prefs_module):
+    prefs_module.record_launch(["tui"], "fastapi", {"port": 8000})
+    prefs_module.record_launch(["tui"], "mqtt")  # no source_params for mqtt
+    assert prefs_module.get_source_params("fastapi") == {"port": 8000}
+
+
+def test_save_prefs_survives_unwritable_path(prefs_module, monkeypatch):
+    """A failed save must not raise -- prefs are a convenience, not critical."""
+    monkeypatch.setattr(prefs_module, "PREFS_FILE", Path("/nonexistent_dir_xyz/prefs.json"))
+    prefs_module.save_prefs({"last_tool_ids": [], "last_source": None, "source_params": {}})  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# menu.py pure-logic helpers
+# ---------------------------------------------------------------------------
+
+def test_available_sources_excludes_direct_for_multi_tool():
+    from benchlab.menu import _available_sources
+    sources = _available_sources(is_multi=True, supported_sources=None)
+    assert "direct" not in [s for s, _ in sources]
+
+
+def test_available_sources_includes_direct_for_single_tool():
+    from benchlab.menu import _available_sources
+    sources = _available_sources(is_multi=False, supported_sources=None)
+    assert "direct" in [s for s, _ in sources]
+
+
+def test_available_sources_filters_by_supported_sources():
+    from benchlab.menu import _available_sources
+    sources = _available_sources(is_multi=False, supported_sources=["direct", "named_pipe"])
+    keys = [s for s, _ in sources]
+    assert set(keys) <= {"direct", "named_pipe"}
+    assert "fastapi" not in keys
+
+
+def test_available_sources_excludes_named_pipe_off_windows(monkeypatch):
+    from benchlab.menu import _available_sources
+    monkeypatch.setattr(sys, "platform", "linux")
+    sources = _available_sources(is_multi=False, supported_sources=None)
+    assert "named_pipe" not in [s for s, _ in sources]
+
+
+# ---------------------------------------------------------------------------
+# menu.py _combined_supported_sources (three-column picker's live filtering)
+# ---------------------------------------------------------------------------
+
+def test_combined_supported_sources_no_tools_selected():
+    from benchlab.menu import _combined_supported_sources
+    assert _combined_supported_sources([]) is None
+
+
+def test_combined_supported_sources_unrestricted_tool():
+    from benchlab.menu import _combined_supported_sources
+    # tui has no supported_sources restriction
+    assert _combined_supported_sources(["tui"]) is None
+
+
+def test_combined_supported_sources_single_restricted_tool():
+    from benchlab.menu import _combined_supported_sources
+    result = _combined_supported_sources(["config"])
+    assert set(result) == {"direct", "named_pipe"}
+
+
+def test_combined_supported_sources_is_intersection_across_tools():
+    """Regression: when multiple tools are selected in the Tools column,
+    the Data Source column must only offer sources ALL selected tools
+    support -- not the union (which could offer a source one of the tools
+    can't actually use)."""
+    from benchlab.menu import _combined_supported_sources, CONSUMER_TOOLS
+
+    # config only supports direct/named_pipe; tui supports everything.
+    # The intersection with an unrestricted tool is still config's set.
+    result = _combined_supported_sources(["config", "tui"])
+    assert set(result) == {"direct", "named_pipe"}
+
+
+def test_combined_supported_sources_disjoint_restrictions_yield_empty():
+    """If two selected tools' supported_sources don't overlap at all, the
+    picker should show 'no compatible source', not silently pick a source
+    one of the tools can't actually use."""
+    from benchlab.menu import _combined_supported_sources, CONSUMER_TOOLS
+    import unittest.mock as mock
+
+    fake_tools = {
+        "a": {"supported_sources": ["direct"]},
+        "b": {"supported_sources": ["mqtt"]},
+    }
+    with mock.patch.dict(CONSUMER_TOOLS, fake_tools, clear=True):
+        result = _combined_supported_sources(["a", "b"])
+    assert result == []
+
+
+# ---------------------------------------------------------------------------
+# menu.py _fuzzy_pick matching + console-encoding safety
+# ---------------------------------------------------------------------------
+
+def test_fuzzy_pick_exact_label_match():
+    from benchlab.menu import _fuzzy_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI - Interactive terminal user interface"),
+             ("vu", "VU Dials - Analog-style VU meter dials")]
+    with mock.patch("builtins.input", return_value=items[0][1]):
+        assert _fuzzy_pick(items, "pick") == "tui"
+
+
+def test_fuzzy_pick_unambiguous_substring_match():
+    from benchlab.menu import _fuzzy_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI - Interactive terminal user interface"),
+             ("vu", "VU Dials - Analog-style VU meter dials")]
+    with mock.patch("builtins.input", return_value="VU"):
+        assert _fuzzy_pick(items, "pick") == "vu"
+
+
+def test_fuzzy_pick_no_match_returns_none():
+    from benchlab.menu import _fuzzy_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI - Interactive terminal user interface")]
+    with mock.patch("builtins.input", return_value="nonsense"):
+        assert _fuzzy_pick(items, "pick") is None
+
+
+def test_fuzzy_pick_ambiguous_substring_returns_none():
+    from benchlab.menu import _fuzzy_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI tool"), ("tui2", "TUI tool alternate")]
+    with mock.patch("builtins.input", return_value="TUI"):
+        assert _fuzzy_pick(items, "pick") is None
+
+
+def test_fuzzy_pick_accepts_number_selection():
+    """A first-time user who doesn't know what to type should be able to
+    just enter the number shown next to an option."""
+    from benchlab.menu import _fuzzy_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI - Interactive terminal user interface"),
+             ("vu", "VU Dials - Analog-style VU meter dials")]
+    with mock.patch("builtins.input", return_value="2"):
+        assert _fuzzy_pick(items, "pick") == "vu"
+
+
+def test_fuzzy_pick_out_of_range_number_returns_none():
+    from benchlab.menu import _fuzzy_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI - Interactive terminal user interface")]
+    with mock.patch("builtins.input", return_value="99"):
+        assert _fuzzy_pick(items, "pick") is None
+
+
+def test_fuzzy_pick_prints_full_option_list_up_front(capsys):
+    """The sequential-fallback picker must show every option before
+    prompting, so a first-time user isn't left guessing what to type."""
+    from benchlab.menu import _fuzzy_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI - Interactive terminal user interface"),
+             ("vu", "VU Dials - Analog-style VU meter dials")]
+    with mock.patch("builtins.input", return_value="1"):
+        _fuzzy_pick(items, "Select a tool:")
+
+    out = capsys.readouterr().out
+    assert "1. TUI - Interactive terminal user interface" in out
+    assert "2. VU Dials - Analog-style VU meter dials" in out
+
+
+def test_multi_pick_parses_comma_separated_numbers():
+    """_multi_pick is the sequential-fallback multi-select (used when the
+    full-screen three-column picker can't run) -- plain input(), no
+    prompt_toolkit dialog involved."""
+    from benchlab.menu import _multi_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI"), ("vu", "VU Dials"), ("graph", "Graph")]
+
+    with mock.patch("builtins.input", return_value="1,3"):
+        assert _multi_pick(items, "Select Tools") == ["tui", "graph"]
+
+
+def test_multi_pick_supports_all():
+    from benchlab.menu import _multi_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI"), ("vu", "VU Dials")]
+
+    with mock.patch("builtins.input", return_value="all"):
+        assert _multi_pick(items, "Select Tools") == ["tui", "vu"]
+
+
+def test_multi_pick_ignores_out_of_range_and_invalid_numbers():
+    from benchlab.menu import _multi_pick
+    import unittest.mock as mock
+
+    items = [("tui", "TUI"), ("vu", "VU Dials")]
+
+    with mock.patch("builtins.input", return_value="1,99,x"):
+        assert _multi_pick(items, "Select Tools") == ["tui"]
+
+
+# ---------------------------------------------------------------------------
+# _sequential_pick (whole fallback flow: mode choice -> tools/provider)
+# ---------------------------------------------------------------------------
+
+def test_sequential_pick_provider_mode_returns_tagged_result():
+    from benchlab.menu import _sequential_pick
+    import unittest.mock as mock
+
+    # First input(): mode choice ("2" = provider). Second: provider choice.
+    with mock.patch("builtins.input", side_effect=["2", "1"]):
+        result = _sequential_pick([], None)
+
+    assert result == ("provider", "fastapi")
+
+
+def test_sequential_pick_tools_mode_returns_tagged_result():
+    from benchlab.menu import _sequential_pick
+    import unittest.mock as mock
+
+    # mode="1" (tools), single/multi="s", tool number, source number.
+    with mock.patch("builtins.input", side_effect=["1", "s", "1", "1"]):
+        result = _sequential_pick([], None)
+
+    assert result[0] == "tools"
+    assert isinstance(result[1], list) and len(result[1]) == 1
+
+
+def test_sequential_pick_cancelled_mode_choice_returns_none():
+    from benchlab.menu import _sequential_pick
+    import unittest.mock as mock
+
+    with mock.patch("builtins.input", side_effect=EOFError):
+        assert _sequential_pick([], None) is None
+
+
+# ---------------------------------------------------------------------------
+# Textual full-screen picker (Tools | Data Source, plus Data Provider tab)
+# ---------------------------------------------------------------------------
+# Driven headlessly via Textual's own App.run_test() pilot -- no real
+# terminal needed, and no extra pytest-asyncio dependency since these
+# wrap a single asyncio.run() per test.
+
+def _run_async(coro):
+    import asyncio
+    return asyncio.run(coro)
+
+
+def test_picker_screen_initial_state_no_defaults():
+    from benchlab.menu import _build_launcher_app
+    from textual.widgets import RadioSet
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._selected_tool_ids() == []
+            # Source list defaults to the first available source when
+            # nothing is selected/remembered, so the picker never opens
+            # with a genuinely empty/unusable source column.
+            radio_set = app.query_one("#sources", RadioSet)
+            assert radio_set.pressed_index == 0
+
+    _run_async(scenario())
+
+
+def test_picker_screen_preselects_remembered_tools_and_source():
+    from benchlab.menu import _build_launcher_app
+
+    async def scenario():
+        app = _build_launcher_app(["tui", "vu"], "fastapi")
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert set(app._selected_tool_ids()) == {"tui", "vu"}
+            assert app._current_source_id() == "fastapi"
+
+    _run_async(scenario())
+
+
+def test_picker_screen_source_list_filters_when_tool_selected():
+    """Regression: the Data Source column must live-update to only the
+    sources compatible with the current Tools selection -- config only
+    supports direct/named_pipe, so selecting it must narrow the source
+    list from the full 7 down to those 2."""
+    from benchlab.menu import _build_launcher_app
+    from textual.widgets import SelectionList
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert len(app._source_ids) == 7  # unrestricted
+
+            tools = app.query_one("#tools", SelectionList)
+            config_option = next(o for o in tools._options if o.value == "config")
+            tools.select(config_option)
+            await pilot.pause()
+
+            assert set(app._source_ids) == {"direct", "named_pipe"}
+
+    _run_async(scenario())
+
+
+def test_picker_screen_deselecting_tool_restores_full_source_list():
+    from benchlab.menu import _build_launcher_app
+    from textual.widgets import SelectionList
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tools = app.query_one("#tools", SelectionList)
+            config_option = next(o for o in tools._options if o.value == "config")
+            tools.select(config_option)
+            await pilot.pause()
+            tools.deselect(config_option)
+            await pilot.pause()
+
+            assert len(app._source_ids) == 7
+
+    _run_async(scenario())
+
+
+def test_picker_screen_launch_button_disabled_with_no_tools_selected():
+    from benchlab.menu import _build_launcher_app
+    from textual.widgets import Button
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            btn = app.query_one("#launch-btn", Button)
+            assert btn.disabled is True
+
+    _run_async(scenario())
+
+
+def test_picker_screen_launch_button_enabled_once_tool_selected():
+    from benchlab.menu import _build_launcher_app
+    from textual.widgets import SelectionList, Button
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tools = app.query_one("#tools", SelectionList)
+            vu_option = next(o for o in tools._options if o.value == "vu")
+            tools.select(vu_option)
+            await pilot.pause()
+
+            btn = app.query_one("#launch-btn", Button)
+            assert btn.disabled is False
+
+    _run_async(scenario())
+
+
+def test_picker_screen_launch_button_sets_result():
+    from benchlab.menu import _build_launcher_app
+    from textual.widgets import SelectionList
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tools = app.query_one("#tools", SelectionList)
+            vu_option = next(o for o in tools._options if o.value == "vu")
+            tools.select(vu_option)
+            await pilot.pause()
+            app.action_launch()
+            await pilot.pause()
+
+            assert app.result == ("tools", ["vu"], "direct")
+
+    _run_async(scenario())
+
+
+def test_picker_screen_quit_key_returns_none_result():
+    from benchlab.menu import _build_launcher_app
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            await pilot.press("q")
+            await pilot.pause()
+            assert app.result is None
+
+    _run_async(scenario())
+
+
+def test_picker_screen_starts_on_tools_tab():
+    from benchlab.menu import _build_launcher_app
+    from textual.widgets import TabbedContent
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            tabs = app.query_one("#mode-tabs", TabbedContent)
+            assert tabs.active == "tab-tools"
+
+    _run_async(scenario())
+
+
+def test_picker_screen_provider_tab_defaults_to_fastapi():
+    from benchlab.menu import _build_launcher_app
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            assert app._current_provider() == "fastapi"
+
+    _run_async(scenario())
+
+
+def test_picker_screen_provider_tab_start_sets_result():
+    """Regression: Data Provider must be reachable from the same picker
+    screen as tools (no separate top-level prompt), and starting it must
+    produce a distinctly-tagged result so interactive_loop() doesn't try
+    to treat a provider choice as a tool launch."""
+    from benchlab.menu import _build_launcher_app
+    from textual.widgets import RadioButton
+
+    async def scenario():
+        app = _build_launcher_app([], None)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            providers = app.query_one("#providers")
+            buttons = list(providers.children)
+            with providers.prevent(RadioButton.Changed):
+                buttons[1].value = True  # mqtt
+            providers._pressed_button = buttons[1]
+
+            app._start_provider()
+            await pilot.pause()
+
+            assert app.result == ("provider", "mqtt")
+
+    _run_async(scenario())
+
+
+def test_run_picker_screen_falls_back_when_textual_app_fails():
+    """Regression: if Textual's App.run() can't start in this terminal
+    (no proper console control, e.g. certain CI/IDE terminals), the
+    picker must degrade to the sequential prompt-based flow rather than
+    crash the whole menu."""
+    from benchlab.menu import _run_picker_screen
+    import unittest.mock as mock
+
+    with mock.patch("benchlab.menu._build_launcher_app") as mock_build:
+        mock_app = mock.MagicMock()
+        mock_app.run.side_effect = RuntimeError("no terminal")
+        mock_build.return_value = mock_app
+
+        with mock.patch("benchlab.menu._sequential_pick", return_value=("tools", ["vu"], "direct")) as mock_seq:
+            result = _run_picker_screen([], None)
+
+        mock_seq.assert_called_once()
+        assert result == ("tools", ["vu"], "direct")
+
+
+def test_menu_module_has_no_non_ascii_runtime_output():
+    """Regression: menu.py originally used Unicode arrows (Up/Down) and
+    em-dashes in printed strings, which crash with UnicodeEncodeError on a
+    plain cp1252 Windows console (the default unless UTF-8 codepage is set).
+    Only the BANNER block (box-drawing art, printed via a single print() the
+    same way menu_classic.py's banner always has been) is exempt."""
+    import benchlab.menu as menu_mod
+    from pathlib import Path
+
+    src = Path(menu_mod.__file__).read_text(encoding="utf-8")
+    lines = src.splitlines()
+
+    in_banner = False
+    offenders = []
+    for lineno, line in enumerate(lines, 1):
+        if line.strip().startswith('BANNER = '):
+            in_banner = True
+            continue
+        if in_banner:
+            if line.strip() == '"""':
+                in_banner = False
+            continue
+        if line.strip().startswith(("#", '"""', "'''")):
+            continue
+        try:
+            line.encode("cp1252")
+        except UnicodeEncodeError:
+            offenders.append((lineno, line))
+
+    assert not offenders, f"Non-cp1252-safe lines outside BANNER: {offenders}"
+
+
+# ---------------------------------------------------------------------------
+# main.py fallback to menu_classic
+# ---------------------------------------------------------------------------
+
+def test_main_falls_back_to_classic_menu_when_menu_import_fails(monkeypatch):
+    for mod in ("benchlab.main", "benchlab.menu"):
+        sys.modules.pop(mod, None)
+    monkeypatch.setitem(sys.modules, "benchlab.menu", None)  # forces ImportError
+
+    import benchlab.main as m
+    assert m.interactive_loop.__module__ == "benchlab.menu_classic"
+
+    # Clean up so later tests re-import the real benchlab.menu
+    sys.modules.pop("benchlab.main", None)
+    sys.modules.pop("benchlab.menu", None)
+    importlib.import_module("benchlab.main")


### PR DESCRIPTION
## Summary

Follow-up to the launcher bug sweep (#37, base of this branch). Replaces the numbered-prompt interactive menu with a full-screen [Textual](https://github.com/Textualize/textual) TUI.

An initial attempt used `prompt_toolkit` (arrow-key/fuzzy pickers, a three-column layout) but was tried and rejected — described as looking "unfinished" and feeling clunky to navigate. Pivoted to Textual for real styled widgets (CSS, borders, colors, focus states).

**Final design**, iterated live with the user across several rounds:

- Launches straight into the picker screen — no separate "what would you like to do" prompt first.
- Two tabs (`TabbedContent`):
  - **"Run Tool(s)"** — a Tools checklist (`SelectionList`, multi-select) stacked *above* a Data Source radio list (`RadioSet`), since tool names run too long for a side-by-side column. The Data Source list live-filters to the intersection of what the currently-selected tool(s) support, and defaults to the last-used source when compatible.
  - **"Data Provider"** — run FastAPI or MQTT standalone (no consumer tool), folded into the same screen as a tab instead of a separate top-level menu option.
- Last-used tool(s)/source pre-selected on open, persisted to a new `.benchlab_prefs.json` (gitignored, repo root) via `benchlab/prefs.py`.
- Source-specific connection params (broker host, API port, etc.) are still prompted for in the terminal after the picker closes, pre-filled from last use — kept out of the TUI to avoid duplicating input validation in two places.
- Falls back automatically to the old numbered-prompt flow (kept as `benchlab/menu_classic.py`) if `textual` isn't installed or the app can't start in the current terminal (no real console control), rather than crashing.

Closes #36.

## Test plan

- [x] `pytest tests/test_menu.py -v` — 42 tests: prefs persistence, source compatibility/intersection logic, the sequential fallback flow, and the Textual app itself driven headlessly via Textual's own `App.run_test()` pilot (simulated tool/source selection, tab switching, launch/quit, live source-list filtering, banner mount) — no real terminal needed, works in CI
- [x] Regression-verified: reverted the `RadioSet._pressed_button` fix and confirmed 2 tests fail with the exact original symptom (`app.result` stuck at `None`); restored and confirmed all pass again
- [x] Manually verified by the user across multiple iterations in a real terminal (prompt_toolkit version rejected; three-column Textual version approved; vertical-stack + tabs + in-app banner follow-up approved)
- [x] `pycore-compat.yml` updated in both `pinned` and `latest` jobs — import smoke test + new pytest step each
- [ ] CI green on this PR