### PR TITLE
Refresh documentation across the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 # Benchlab specific files
 *.db
+*.db-journal
 *.config
 *.pid.lock
 .benchlab_prefs.json
+my_config.json
+/logs/
 benchlab/vu/generated/
 benchlab/vu/VU-Server/upload/
 

--- a/README.md
+++ b/README.md
@@ -1,151 +1,149 @@
 # BENCHLAB PyTools
 
-## Overview
+BENCHLAB PyTools is the Python-based control suite for BENCHLAB telemetry devices. It provides a shared telemetry pipeline — device discovery, data sourcing, and process management — plus a set of consumer tools built on top of it:
 
-BENCHLAB PyTools is the main entry point for interacting with BENCHLAB telemetry devices using Python.  
-It provides a modular launcher to start different modes of operation, including:
+- **TUI** — interactive terminal dashboard for live monitoring
+- **CSV Logger** — fleet-wide telemetry logging for offline analysis
+- **FastAPI Server** — REST API for telemetry, exposed for other tools/integrations
+- **Graph** — DearPyGui-based real-time sensor graphing
+- **HWiNFO Export** — exposes sensors as HWiNFO64 custom sensors
+- **MQTT Publisher** — publishes telemetry to a local or remote MQTT broker
+- **Link** — publishes telemetry to the BENCHLAB cloud (SaaS) MQTT broker
+- **VU Dials** — analog-style VU meter dial display and configuration
+- **WigiDash** — telemetry/graph display on a G.SKILL WigiDash panel
+- **Config Tool** — import/export device configuration (fan curves, RGB, etc.) via JSON
 
-- Interactive terminal TUI
-- CSV logging for offline analysis
-- Fast api server
-- GUI graphing
-- HWiNFO custom sensors
-- MQTT publishing for remote dashboards
-- VU analog-style dials and configuration
-- WigiDash support for telemetry & graph
-
-The launcher can operate in interactive mode or via command-line flags.
-
----
-
-## Available Modes
-
-| Mode | Flag | Description | Notes |
-|------|------|------------|-------|
-| CSV Logging | -logfleet | Logs device data to CSV | Supports single-device and fleet logging. |
-| Fast API | -fastapi | Access device telemetry through API calls | Supports multi-device |
-| Graph | -graph | GUI graphing interface | Visualizes telemetry trends in real time. |
-| HWiNFO | -hwinfo | HWiNFO export | Export telemetry as HWiNFO custom sensors |
-| MQTT Publisher | -mqtt | Publishes telemetry to MQTT broker | Can connect to localhost or a remote broker. |
-| TUI | -tui | Interactive terminal UI | Displays a live TUI for monitoring multiple devices. |
-| VU Dials | -vu | Analog-style VU dials | Visual monitoring of device metrics. |
-| VU Config | -vuconfig | VU configuration interface | Customize VU dials and settings interactively. |
-| WigiDash | -wigidash | PC Command Panel | Display BENCHLAB telemetry on separate panel. |
+All tools share a common data-source layer, so the same telemetry can be read directly from a device, through a FastAPI server, over MQTT, or via the Windows BENCHLAB service — locally or remotely — without changing the consumer tool.
 
 ---
 
 ## Installation
 
-BENCHLAB PyTools relies on Python 3.8+ and optional modules for each mode.  
+Requires Python 3.10+.
 
-Install core dependencies:
-
-```
+```bash
 pip install -r requirements.txt
 ```
 
-Optional mode-specific dependencies are in:
-
-- `/fastapi/requirements.txt`
-- `/tests/requirements.txt`
-- `/vu/requirements.txt`
-
-The launcher will attempt to install missing requirements for selected modes automatically.
+Each tool has its own `requirements.txt` (e.g. `benchlab/graph/requirements.txt`, `benchlab/vu/requirements.txt`). The launcher installs a tool's requirements automatically the first time it's run — you generally don't need to install them by hand.
 
 ---
 
 ## Usage
 
-### Interactive Launcher
+### Interactive Menu
 
-Start without arguments:
+Run with no arguments to enter the interactive launcher:
 
-```
+```bash
 python benchlab.py
 ```
 
-- Presents a menu to select modes and features.
-- Optionally installs requirements for selected modes.
-- Allows selecting which mode to start immediately.
+or equivalently:
+
+```bash
+python -m benchlab
+```
+
+The interactive menu (prompt_toolkit-based, with a plain-input fallback if `prompt_toolkit` isn't installed) lets you pick a data source and one or more tools, then launches them — installing any missing per-tool dependencies along the way.
 
 ### Command-Line Flags
 
-Run directly using flags:
+Each tool can also be launched directly with a flag:
 
-```
-python benchlab.py -fastapi
-python benchlab.py -graph
-python benchlab.py -hwinfo
-python benchlab.py -logfleet
-python benchlab.py -mqtt
-python benchlab.py -vu
-python benchlab.py -vuconfig
-python benchlab.py -wigidash
-python benchlab.py -tui
-```
-
-### Info Mode
-
-```
-python benchlab.py -info
+```bash
+python -m benchlab -tui         # Interactive terminal dashboard
+python -m benchlab -logfleet    # CSV logger (no TUI)
+python -m benchlab -fastapi     # FastAPI telemetry server
+python -m benchlab -graph       # DearPyGui graph
+python -m benchlab -hwinfo      # HWiNFO custom sensor export
+python -m benchlab -mqtt [broker]  # MQTT publisher (default broker: localhost)
+python -m benchlab -link        # Publish telemetry to BENCHLAB cloud (Link)
+python -m benchlab -vu          # VU analog dials
+python -m benchlab -vuconfig    # VU dial configuration UI
+python -m benchlab -wigidash    # WigiDash display
+python -m benchlab -config ...  # Device configuration import/export
 ```
 
-Displays detailed mode descriptions and exits.
+Running with no flags is equivalent to launching the interactive menu.
+
+### Data Sources
+
+Most tools accept `--source` to choose where telemetry comes from:
+
+| Source | Description |
+|---|---|
+| `direct` (default) | Direct USB-serial connection via `benchlab-pycore` |
+| `fastapi` | Local FastAPI server, started automatically if not already running |
+| `fastapi_custom` | Remote FastAPI server — requires `--api-url` |
+| `mqtt` | Local MQTT broker + publisher, started automatically if needed |
+| `mqtt_custom` | Remote/existing MQTT broker — requires `--mqtt-broker`/`--mqtt-port` |
+| `named_pipe` | Windows BENCHLAB service (`BL_Service`) via named pipes — Windows only |
+| `service_http` | Windows BENCHLAB service HTTP API — requires `--service-url` (default `http://localhost:8585`) |
+
+Common connection flags:
+
+```
+--source SOURCE          direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http
+--api-url URL             FastAPI base URL (default: http://127.0.0.1:8000)
+--api-port PORT           FastAPI port (default: 8000)
+--mqtt-broker HOST         MQTT broker host (default: localhost)
+--mqtt-port PORT           MQTT broker port (default: 1883)
+--service-url URL          BENCHLAB Windows service HTTP API URL (default: http://localhost:8585)
+-i, --interval SECONDS     Refresh interval (default: 1.0)
+```
+
+When a source needs a background service (`fastapi`, `mqtt`), the launcher starts and health-checks it automatically, and tears it down on exit. Not every tool supports every source — the config tool, for example, only supports `direct` and `named_pipe`. See each tool's README for specifics.
+
+### Launch Profiles
+
+A named profile can bundle a data source and a set of tools to start together:
+
+```bash
+python -m benchlab --profile gskill_ctex26
+```
+
+Profiles are defined in `benchlab/tools.py` (`LAUNCH_PROFILES`). Each spawns its tools in separate terminal windows and manages them as a group.
 
 ---
 
-## Launcher Behavior
+## Architecture
 
-1. **Mode Selection**
-   - Interactive menu lists all modes with descriptions.
-   - User can select one or multiple modes.
-   - If `all` is selected, launcher installs dependencies for all available modules.
+- `benchlab/main.py` — CLI argument parsing and mode dispatch (`launch_mode()`)
+- `benchlab/launcher.py` — in-process and multi-terminal tool launching, process lifecycle
+- `benchlab/sources.py` — data-source detection, startup, and teardown for all supported sources
+- `benchlab/tools.py` — the `CONSUMER_TOOLS` registry (tool metadata, module/function to invoke, dependencies) and `LAUNCH_PROFILES`
+- `benchlab/menu.py` / `benchlab/menu_classic.py` — interactive terminal menu (prompt_toolkit, with a plain-input fallback)
+- `benchlab/core/` — shared internals used by every tool: device discovery, the data-source abstraction, process management, retry logic. See [benchlab/core/README.md](benchlab/core/README.md).
 
-2. **Dependency Installation**
-   - Checks for `/*/requirements.txt` per mode.
-   - Silently skips missing requirement files.
-   - Installs via pip if present.
+Each consumer tool lives in its own subpackage under `benchlab/` with its own README, and (where needed) its own `requirements.txt`.
 
-3. **Mode Execution**
-   - Rewrites `sys.argv` to dispatch to the selected mode.
-   - Default behavior launches TUI if no flags are provided.
-   - Each mode is isolated; missing modules produce informative messages.
+### Adding a New Tool
 
----
-
-## Developer Notes
-
-### Modular Design
-
-- `MODES` dictionary defines available modes, flags, requirements, and descriptions.
-- `launch_mode()` handles CLI dispatching to mode-specific runners.
-- Default TUI mode uses `curses.wrapper` for terminal display.
-
-### Adding New Modes
-
-1. Add a new entry to the `MODES` dictionary with:
-   - `flag`, `reqs`, `desc`, `info`.
-2. Implement a corresponding runner in `benchlab.<module>` and import it in `launch_mode()`.
-3. Optionally provide a `requirements_<tag>.txt` file.
-
-### Interactive Menu
-
-- Clears the screen and shows mode selection.
-- Supports comma-separated input (e.g., `1,3,5`) or `all`.
-- Supports an info view with detailed mode descriptions.
-- Automatically installs requirements for selected modes if available.
+1. Add an entry to `CONSUMER_TOOLS` in `benchlab/tools.py` with `name`, `flag`, `module`, `function`, and `requirements`.
+2. Implement the tool's entry function in its module, accepting an `args` namespace (see `benchlab/launcher.py::_build_args_namespace`).
+3. Add a CLI flag for it in `benchlab/main.py::get_parser()` and dispatch it in `launch_mode()`.
+4. Add a `requirements.txt` in the tool's directory if it has extra dependencies.
+5. Write a `README.md` in the tool's directory following the style of the existing ones.
 
 ---
 
-## References
+## Tool Documentation
 
-- [BENCHLAB core modules](https://github.com/<your-org>/benchlab/tree/main/benchlab/core)  
-- Individual module READMEs:
-  - [CSV Logger](../csv_log/README.md)
-  - [FASTAPI](../fastapi/README.md)
-  - [Graph](../graph/README.md)
-  - [HWiNFO](../hwinfo/README.md)
-  - [MQTT](../mqtt/README.md)
-  - [VU](../vu/README.md)
-  - [WIGIDASH](../wigidash/README.md)
-  - [TUI](../tui/README.md)
+- [Config Tool](benchlab/config/README.md) — device configuration import/export
+- [Core](benchlab/core/README.md) — shared internals (data sources, process management, discovery)
+- [CSV Logger](benchlab/csv_log/README.md)
+- [FastAPI Server](benchlab/restapi/readme.md)
+- [Graph](benchlab/graph/README.md)
+- [HWiNFO Export](benchlab/hwinfo/README.md)
+- [Link](benchlab/link/README.md) — publish telemetry to BENCHLAB cloud
+- [MQTT Publisher](benchlab/mqtt/README.md)
+- [TUI](benchlab/tui/README.md)
+- [VU Dials](benchlab/vu/README.md)
+- [WigiDash](benchlab/wigidash/README.md)
+
+---
+
+## License
+
+Part of BENCHLAB PyTools. See main project license for details.

--- a/benchlab/config/README.md
+++ b/benchlab/config/README.md
@@ -36,7 +36,7 @@ pip install pywin32
 Simply run the tool without arguments to enter interactive mode:
 
 ```bash
-python benchlab.py -config
+python -m benchlab -config
 ```
 
 This will:
@@ -51,23 +51,23 @@ This will:
 
 ```bash
 # List devices via direct serial
-python benchlab.py -config --list
+python -m benchlab -config --list
 
 # List devices via named pipe (Windows only)
-python benchlab.py -config --list --source named_pipe
+python -m benchlab -config --list --source named_pipe
 ```
 
 #### Export Configuration
 
 ```bash
 # Export from first available device
-python benchlab.py -config --export my_config.json
+python -m benchlab -config --export my_config.json
 
 # Export from specific device
-python benchlab.py -config --export my_config.json --device COM4
+python -m benchlab -config --export my_config.json --device COM4
 
 # Export via named pipe
-python benchlab.py -config --export my_config.json --source named_pipe
+python -m benchlab -config --export my_config.json --source named_pipe
 ```
 
 #### Import Configuration
@@ -76,18 +76,18 @@ python benchlab.py -config --export my_config.json --source named_pipe
 # Import configuration - shows a diff of what would actually change on the
 # device (current value -> new value, only changed fields), then asks for
 # confirmation before applying
-python benchlab.py -config --import my_config.json
+python -m benchlab -config --import my_config.json
 
 # Preview changes without applying anything (still connects to the device
 # and reads its current config to compute the diff)
-python benchlab.py -config --import my_config.json --dry-run
+python -m benchlab -config --import my_config.json --dry-run
 
 # Apply without the confirmation prompt (diff is still printed) - for
 # scripts/automation
-python benchlab.py -config --import my_config.json --yes
+python -m benchlab -config --import my_config.json --yes
 
 # Import via named pipe
-python benchlab.py -config --import my_config.json --source named_pipe
+python -m benchlab -config --import my_config.json --source named_pipe
 ```
 
 ## JSON Configuration Format
@@ -187,7 +187,7 @@ Example configurations are provided in `benchlab/config/examples/`:
 Set all fans to 50% fixed speed:
 
 ```bash
-python benchlab.py -config --import benchlab/config/examples/simple_fan.json
+python -m benchlab -config --import benchlab/config/examples/simple_fan.json
 ```
 
 ### RGB Lighting
@@ -195,7 +195,7 @@ python benchlab.py -config --import benchlab/config/examples/simple_fan.json
 Set RGB to solid blue:
 
 ```bash
-python benchlab.py -config --import benchlab/config/examples/rgb_lighting.json
+python -m benchlab -config --import benchlab/config/examples/rgb_lighting.json
 ```
 
 ### Complete Configuration
@@ -203,7 +203,7 @@ python benchlab.py -config --import benchlab/config/examples/rgb_lighting.json
 Full device setup with fan curves, RGB, and device name:
 
 ```bash
-python benchlab.py -config --import benchlab/config/examples/complete_config.json
+python -m benchlab -config --import benchlab/config/examples/complete_config.json
 ```
 
 ## Data Sources

--- a/benchlab/config/config_tool.py
+++ b/benchlab/config/config_tool.py
@@ -252,24 +252,24 @@ def main(args=None):
             epilog="""
 Examples:
   # List devices
-  python benchlab.py -config --list
+  python -m benchlab -config --list
 
   # Export configuration
-  python benchlab.py -config --export config.json
-  python benchlab.py -config --export config.json --device COM4
+  python -m benchlab -config --export config.json
+  python -m benchlab -config --export config.json --device COM4
 
   # Import configuration (shows a diff of what would change, then asks to confirm)
-  python benchlab.py -config --import config.json
+  python -m benchlab -config --import config.json
 
   # Preview changes without applying anything
-  python benchlab.py -config --import config.json --dry-run
+  python -m benchlab -config --import config.json --dry-run
 
   # Apply without the confirmation prompt (for scripts/automation)
-  python benchlab.py -config --import config.json --yes
+  python -m benchlab -config --import config.json --yes
 
   # Use named pipe source (Windows only)
-  python benchlab.py -config --list --source named_pipe
-  python benchlab.py -config --import config.json --source named_pipe
+  python -m benchlab -config --list --source named_pipe
+  python -m benchlab -config --import config.json --source named_pipe
             """
         )
 

--- a/benchlab/core/README.md
+++ b/benchlab/core/README.md
@@ -1,36 +1,44 @@
-# BENCHLAB Core - Data Source Abstraction Layer
+# BENCHLAB Core - Shared Internals
 
-This module provides a unified architecture for BENCHLAB tools to consume telemetry data from multiple sources, enabling multiple tools to run simultaneously without serial port conflicts.
+`benchlab/core/` is the internal library used by every BENCHLAB PyTools tool (TUI, FastAPI server, MQTT publisher, Link, HWiNFO export, VU dials, WigiDash, config tool). It provides the data-source abstraction that lets multiple tools consume telemetry without fighting over a serial port, plus supporting infrastructure: device lifecycle tracking, subprocess management, retry helpers, and statistics.
+
+This is a developer-facing internals doc. For CLI usage of individual tools, see their own READMEs (`benchlab/restapi/readme.md`, `benchlab/mqtt/README.md`, `benchlab/config/README.md`, `benchlab/link/README.md`).
 
 ## Architecture Overview
 
 ### The Problem
 
-The original architecture had each tool directly connecting to the serial port via `benchlab_pycore`. Since only one process can claim a serial port at a time, this prevented running multiple tools simultaneously.
+Only one process can own a serial port at a time. If every tool connected directly via `benchlab_pycore`, only one tool could ever run at once.
 
 ### The Solution
 
-A **Data Source Abstraction Layer** that allows tools to consume data from:
-
-1. **Direct** - Direct serial connection via pycore (for single tool)
-2. **FastAPI** - HTTP REST API server (recommended for multiple tools)
-3. **MQTT** - MQTT broker subscription
+A **DataSource abstraction layer** (`datasource.py`) with multiple implementations, all exposing the same interface. Tools pick a source type via `--source` and don't need to know how the data actually gets to them.
 
 ## Components
 
-### 1. DataSource Classes (`datasource.py`)
+### 1. DataSource classes (`datasource.py`)
 
-Abstract base class and implementations:
+`DataSource` is an abstract base class (`connect`, `disconnect`, `is_connected`, `list_devices`, `get_telemetry(uid)`, `get_device_info(uid)`, `source_type`). Concrete implementations:
+
+| Class | `source_type` | Description |
+|---|---|---|
+| `DirectDataSource` | `direct` | Connects directly to the serial port via `benchlab_pycore`. Runs its own background polling thread. Exclusive port access — only one tool. |
+| `FastAPIDataSource` | `fastapi` / `fastapi_custom` | HTTP client for the `benchlab.restapi` server. Polls `/health`, `/devices`, `/device/{uid}/telemetry`, `/device/{uid}/info` via `requests`. |
+| `MQTTDataSource` | `mqtt` / `mqtt_custom` | Subscribes to `<topic_prefix>/+/telemetry` and `<topic_prefix>/+/info` on an MQTT broker via `paho-mqtt`. Resolves `MQTT_PROTOCOL` (v3.1 / v3.1.1 / v5) via the module-level `resolve_mqtt_protocol()` helper. |
+| `NamedPipeDataSource` | `named_pipe` | Windows-only. Talks to the C# BENCHLAB Windows service over named pipes (`BenchlabDiscovery` for device listing, per-device `BenchlabSensorPipe_XX_YYY` pipes for telemetry). Normalizes the C# service's `ShortName`-keyed sensor payloads into the same flat key names Python tools expect, via the module-level `_normalise_cs_telemetry()` helper. |
+| `ServiceHttpDataSource` | `service_http` | REST client for the C# BENCHLAB service's HTTP API (default `http://localhost:8585`). Thin client only — does not start/manage the service. Same telemetry normalization as `NamedPipeDataSource`. |
+
+Each implementation validates its constructor kwargs through a Pydantic model in `config.py` (`SerialConfig`, `FastAPIConfig`, `MQTTConfig`, `NamedPipeConfig`, `ServiceHttpConfig`).
+
+The `create_datasource(source_type, **kwargs)` factory function builds the right class:
 
 ```python
 from benchlab.core import create_datasource
 
-# Factory function - creates appropriate DataSource
 datasource = create_datasource('fastapi', base_url='http://127.0.0.1:8000')
 datasource = create_datasource('direct', port='COM3')
 datasource = create_datasource('mqtt', broker='localhost', port=1883)
 
-# Common API
 datasource.connect()
 devices = datasource.list_devices()
 telemetry = datasource.get_telemetry(uid)
@@ -38,218 +46,109 @@ device_info = datasource.get_device_info(uid)
 datasource.disconnect()
 ```
 
-### 2. Infrastructure Manager (`infrastructure.py`)
+### 2. DataSourceManager (`datasource_manager.py`)
 
-Manages starting/stopping FastAPI server and MQTT publisher:
-
-```python
-from benchlab.core import InfrastructureManager
-
-infra = InfrastructureManager(fastapi_port=8000)
-
-# Start infrastructure based on tool requirements
-tools = [{'source': 'fastapi'}, {'source': 'mqtt'}]
-infra.start_all(tools)
-
-# ... run tools ...
-
-infra.stop_all()
-```
-
-### 3. Launcher Utilities (`launcher.py`)
-
-Interactive multi-tool selection and launching:
+Wraps any `DataSource` with a consistent, higher-level API used by tools (TUI, Link, etc.): connection management, a background polling thread, device selection, and a single `snapshot()` call for UI/consumer code.
 
 ```python
-from benchlab.core.launcher import run_interactive_launcher
+from benchlab.core.datasource_manager import DataSourceManager
 
-# Run interactive menu
-run_interactive_launcher()
+mgr = DataSourceManager(source_type='fastapi', base_url='http://127.0.0.1:8000')
+mgr.connect()
+mgr.select_device(uid)
+snap = mgr.snapshot()
+# snap: connected, source_type, source_desc, port, uid, device_info,
+#       sensor_data, connection_time, last_error, all_devices, all_telemetry
 ```
 
-## Usage
+Also accepts an optional `stats_callback(uid, channel, value)` invoked on every changed numeric telemetry value, typically wired to a `ChannelStats` instance (see below).
 
-### Single Tool Mode (Backward Compatible)
+### 3. DeviceRegistry (`device_registry.py`)
 
-Existing single-tool commands still work:
+Thread-safe singleton (`DeviceRegistry.get_instance()`) that is the single source of truth for "which devices exist right now." Exactly one component per process should own registration — e.g. the FastAPI server registers/unregisters devices as its reader threads start and stop. Other tools only observe via `get_devices()`, `get_device(uid)`, `has_device(uid)`, or subscribe to `on_connect(callback)` / `on_disconnect(callback)` events. `update_telemetry(uid)` stamps a device's `last_telemetry` time.
 
-```bash
-python benchlab.py -tui
-python benchlab.py -hwinfo
-python benchlab.py -fastapi
-```
+### 4. ProcessManager (`process_manager.py`)
 
-### Multi-Tool Mode - Interactive
-
-```bash
-python benchlab.py -multi
-```
-
-This launches an interactive menu where you can:
-1. Select multiple tools to run
-2. Choose data source (FastAPI recommended)
-3. Launcher automatically starts infrastructure
-4. Tools run simultaneously
-
-### Multi-Tool Mode - Command Line
-
-```bash
-# Launch specific tools with automatic data source selection
-python benchlab.py -tools tui hwinfo graph
-
-# Specify data source explicitly
-python benchlab.py -tools tui hwinfo -source fastapi
-
-# Custom FastAPI port
-python benchlab.py -tools tui hwinfo -source fastapi -fastapi-port 9000
-```
-
-## Data Source Details
-
-### Direct Source
-- **Use case**: Single tool that needs low-latency access
-- **Pros**: Lowest latency, no overhead
-- **Cons**: Exclusive serial port access, only one tool
-- **Implementation**: `DirectDataSource` uses pycore directly
-
-### FastAPI Source
-- **Use case**: Multiple tools, web dashboards, remote access
-- **Pros**: HTTP-based (firewall-friendly), supports multiple clients, REST API
-- **Cons**: Small latency overhead (~10-50ms)
-- **Implementation**: `FastAPIDataSource` makes HTTP requests to FastAPI server
-- **Server**: Automatically started by `InfrastructureManager` on port 8000 (default)
-
-### MQTT Source
-- **Use case**: Distributed systems, IoT integration
-- **Pros**: Pub/sub model, works with existing MQTT infrastructure
-- **Cons**: Requires MQTT broker, more complex setup
-- **Implementation**: `MQTTDataSource` subscribes to telemetry topics
-- **Publisher**: Automatically started by `InfrastructureManager`
-
-## Tool Refactoring Status
-
-Tools need to be refactored to use the DataSource abstraction:
-
-- [x] **Core infrastructure** - DataSource classes, InfrastructureManager
-- [x] **Launcher** - Multi-tool selection and orchestration
-- [ ] **TUI** - In progress (DataSourceWorker created)
-- [ ] **HWiNFO** - Needs refactoring
-- [ ] **CSV Logger** - Needs refactoring
-- [ ] **Graph** - Needs refactoring
-- [ ] **VU Dials** - Needs refactoring
-- [ ] **WigiDash** - Needs refactoring
-
-### Refactoring Pattern
-
-Each tool should:
-
-1. Accept a `datasource` parameter (or create one based on config)
-2. Replace direct serial calls with DataSource API
-3. Handle cases where `sensor_struct` is None (only available in direct mode)
-
-Example:
+Thread-safe singleton (`ProcessManager.get_instance()`) for starting/stopping infrastructure subprocesses (e.g. a spawned FastAPI server or MQTT publisher process) with health checks:
 
 ```python
-# Before
-from benchlab_pycore.core import read_sensors, open_serial_connection
-ser = open_serial_connection(port)
-sensors = read_sensors(ser)
-
-# After
-from benchlab.core import create_datasource
-datasource = create_datasource('fastapi')
-datasource.connect()
-telemetry = datasource.get_telemetry(uid)
+pm = ProcessManager.get_instance()
+pm.start_service(
+    name="fastapi",
+    cmd=["python", "-m", "benchlab", "-fastapi"],
+    health_check=lambda: ping_http("http://127.0.0.1:8000/health"),
+    timeout=20,
+)
+pm.stop_service("fastapi")
+pm.shutdown_all()
 ```
 
-## Configuration
+Redirects each service's stdout/stderr to `logs/svc_<name>_stdout.log` / `_stderr.log`. Stopping tries graceful termination (SIGTERM / `taskkill`) first, then force-kills after a timeout.
 
-### Environment Variables
+### 5. InfrastructureManager (`infrastructure.py`)
 
-FastAPI server:
-- `LOG_LEVEL` - Logging level (default: INFO)
-- `POLL_INTERVAL` - Sensor poll interval (default: 1.0)
-- `HISTORY_LENGTH` - Number of historical records (default: 10)
-- `API_HOST` - Server host (default: 0.0.0.0)
-- `API_PORT` - Server port (default: 8000)
+Higher-level, non-singleton orchestrator used by the multi-tool launcher path: starts a FastAPI server as a `uvicorn` subprocess (`start_fastapi`) or an MQTT publisher as a background thread (`start_mqtt_publisher`), detecting if a compatible service is already listening on the target port before starting a new one. `start_all(tools)` / `stop_all()` take a list of tool configs and start only what's needed. Usable as a context manager.
 
-MQTT publisher:
-- `MQTT_BROKER` - Broker hostname (default: localhost)
-- `MQTT_PORT` - Broker port (default: 1883)
-- `MQTT_USERNAME` - Optional username
-- `MQTT_PASSWORD` - Optional password
-- `MQTT_QOS` - QoS level (default: 0)
-- `MQTT_POLL_RATE` - Publish interval (default: 1.0)
+### 6. Discovery (`discovery.py`)
 
-### Command-Line Arguments
+`discover_devices()` — the canonical way to enumerate connected BENCHLAB devices over direct serial. Uses `benchlab_pycore.core.get_benchlab_ports()` to find candidate ports, opens each, reads UID/firmware/product ID, and returns `{"uid", "port", "fw", "variant"}` dicts (`variant` is `"ORIGINAL"` or `"BL2"`). Wrapped in the `retry` decorator (3 attempts, exponential backoff).
 
-Multi-tool mode:
-- `-multi` - Interactive multi-tool selector
-- `-tools <tool1> <tool2> ...` - Launch specific tools
-- `-source <direct|fastapi|mqtt>` - Data source type
-- `-fastapi-port <port>` - Custom FastAPI port (default: 8000)
+### 7. Retry (`retry.py`)
 
-## Migration Guide
+`RetryPolicy` (dataclass: `max_retries`, `backoff_factor`, `base_delay`, `allowed_exceptions`) plus a `retry(policy)` decorator that retries a wrapped callable with exponential backoff, logging each attempt. Used throughout `datasource.py` and `discovery.py` for connection attempts.
 
-### For Tool Developers
+### 8. Shared serial (`shared_serial.py`)
 
-1. **Import the core module**:
-   ```python
-   from benchlab.core import create_datasource, InfrastructureManager
-   ```
+`open_serial_connection(port)` — the one place that actually calls `serial.Serial(port, 115200, timeout=1)`; returns `None` instead of raising on failure. All direct-serial code paths (`DirectDataSource`, `discovery.py`, `telemetry_api.py`) use this instead of talking to `pyserial` directly, so the "None on failure" contract is consistent everywhere.
 
-2. **Replace serial connection**:
-   ```python
-   # Old way
-   ser = open_serial_connection(port)
-   sensors = read_sensors(ser)
-   
-   # New way
-   datasource = create_datasource(source_type, **kwargs)
-   datasource.connect()
-   telemetry = datasource.get_telemetry(uid)
-   ```
+Also provides `SharedSerialManager`, a singleton connection pool keyed by port with reference counting (`acquire_connection` / `release_connection`), so multiple in-process consumers can share one open port instead of each opening their own handle. `SharedConnection` is the context-manager wrapper returned by `acquire_connection`.
 
-3. **Handle missing sensor_struct**:
-   ```python
-   # sensor_struct is only available in direct mode
-   if datasource.source_type == 'direct':
-       # Use sensor_struct for detailed info
-       pass
-   else:
-       # Use telemetry dict only
-       pass
-   ```
+### 9. Statistics (`statistics.py`)
 
-4. **Update argument parsing**:
-   ```python
-   parser.add_argument('-source', choices=['direct', 'fastapi', 'mqtt'],
-                       default='direct', help='Data source type')
-   ```
+`ChannelStats` — thread-safe per-device, per-channel running min/max/average tracker (`update`, `get`, `get_all`, `reset`, `get_devices`, `get_channels`, `has_data`). `StatsFormatter` provides display helpers (`format_stat_string`, `format_compact_range`). `create_stats_callback(stats)` builds a `(uid, channel, value) -> None` callback suitable for `DataSourceManager(stats_callback=...)`.
 
-### For Users
+### 10. Config models (`config.py`)
 
-**Existing workflows continue to work** - no changes needed for single-tool usage.
+Pydantic models validating each DataSource's constructor kwargs: `SerialConfig`, `FastAPIConfig` (normalizes `base_url` to include a scheme and strips trailing slash), `MQTTConfig`, `NamedPipeConfig`, `ServiceHttpConfig`.
 
-To use multiple tools:
-1. Run `python benchlab.py -multi`
-2. Select tools from the menu
-3. Choose FastAPI as data source (recommended)
-4. Tools will run simultaneously
+## Package exports (`benchlab/core/__init__.py`)
 
-## Benefits
+```python
+from benchlab.core import (
+    DataSource, DirectDataSource, FastAPIDataSource, MQTTDataSource, create_datasource,
+    DataSourceManager,
+    ChannelStats, StatsFormatter, create_stats_callback,
+    DeviceRegistry, DeviceInfo,
+    ProcessManager, ManagedProcess,
+    BENCHLAB_ORIGINAL_PRODUCT_ID, BENCHLAB_BL2_PRODUCT_ID,
+)
+```
 
-1. **No serial port conflicts** - Multiple tools can run simultaneously
-2. **Flexible deployment** - Tools can run on different machines (via network)
-3. **Extensible** - Easy to add new data sources
-4. **Backward compatible** - Existing single-tool commands still work
-5. **Clean separation** - Tools don't need to know about data source details
+`NamedPipeDataSource` and `ServiceHttpDataSource` live in `datasource.py` but aren't re-exported from `__init__.py`; import them directly from `benchlab.core.datasource` if needed. `BENCHLAB_ORIGINAL_PRODUCT_ID` / `BENCHLAB_BL2_PRODUCT_ID` are re-exported from `benchlab_pycore` (with a fallback to hardcoded `0x10`/`0x11` if pycore isn't installed) so tools can detect device variant without importing pycore directly.
 
-## Future Enhancements
+## How tools use this
 
-- [ ] Hot-reload configuration changes
-- [ ] WebSocket support for real-time streaming
-- [ ] Data source failover (auto-switch if one fails)
-- [ ] Remote data source (tools on different machines)
-- [ ] Data source health monitoring
-- [ ] Automatic tool restart on failure
+- **`benchlab/main.py`** resolves `--source` into environment variables via `_setup_source_from_args()` and calls `check_and_setup_source()` (in `benchlab/sources.py`) to start/verify the chosen source before launching a tool.
+- **`benchlab/restapi/telemetry_api.py`** is a *producer*: it owns the serial port directly, registers devices in `DeviceRegistry`, and serves `DirectDataSource`-equivalent data to `FastAPIDataSource` clients.
+- **`benchlab/mqtt/mqtt_publisher.py`** is also a producer: reads sensors directly and publishes to an MQTT broker for `MQTTDataSource` clients.
+- **`benchlab/link/link_main.py`** is a consumer: uses `DataSourceManager` against any local source (direct/fastapi/mqtt) and republishes telemetry to a remote/cloud MQTT broker.
+- **`benchlab/tui/`**, **VU dials**, **WigiDash**, **HWiNFO export**, **CSV logger** are consumers via `DataSourceManager` or `create_datasource` directly.
+- The **config tool** (`benchlab/config/`) does not use the DataSource abstraction — it has its own direct/named-pipe client layer (`config_client.py`) for read/write configuration operations, since DataSource is read-only telemetry.
+
+## Data Source Comparison
+
+| Source | Use case | Pros | Cons |
+|---|---|---|---|
+| `direct` | Single tool, lowest latency | No overhead, no extra process | Exclusive port access, only one tool |
+| `fastapi` / `fastapi_custom` | Multiple tools, remote access | HTTP-based, firewall-friendly, multi-client | Small latency overhead, requires a running server |
+| `mqtt` / `mqtt_custom` | Distributed/IoT integration | Pub/sub, works with existing MQTT infra | Requires a broker, more moving parts |
+| `named_pipe` | Windows, alongside the C# BENCHLAB service | Multiple tools, no direct serial management | Windows only, requires the service + pywin32 |
+| `service_http` | Windows, alongside the C# BENCHLAB service | HTTP-based, multi-client | Windows-oriented, requires the service running |
+
+## See Also
+
+- [BENCHLAB PyTools Documentation](../../README.md) - Main PyTools documentation
+- [FastAPI Telemetry Server README](../restapi/readme.md)
+- [MQTT Publisher README](../mqtt/README.md)
+- [Config Tool README](../config/README.md)
+- [Link README](../link/README.md)

--- a/benchlab/csv_log/README.md
+++ b/benchlab/csv_log/README.md
@@ -34,11 +34,13 @@ The Enhanced CSV Fleet Logger provides robust, lightweight telemetry logging for
 
 ## Installation
 
-The enhanced logger uses the same dependencies as the original:
+Install the tool's dependencies (from `benchlab/csv_log/requirements.txt`):
 
 ```bash
-pip install -r requirements.txt
+pip install -r benchlab/csv_log/requirements.txt
 ```
+
+Key dependencies: `pyserial`, `benchlab-pycore`.
 
 ---
 
@@ -46,40 +48,31 @@ pip install -r requirements.txt
 
 ### Configuration File
 
-Create a `csv_logger.config` file in your working directory:
+Create a `csv_logger.config` file in your working directory. Only the settings below are actually read by `LoggerConfig`/`load_config()`; other keys are ignored:
 
 ```ini
 [logger]
-# Basic settings
 interval = 1.0                    # Logging interval in seconds
 output_dir = logs                 # Output directory
-buffer_size = 100                 # Buffer size before writing
-format = csv                      # Output format: csv or json
-silent_mode = false              # Silent operation
-auto_select = false              # Auto-select all devices
-
-# Error handling
-retry_attempts = 3               # Number of retry attempts
-retry_delay = 1.0                # Initial retry delay (exponential backoff)
-
-[advanced]
-enable_monitoring = true         # Enable connection monitoring
-monitor_interval = 5             # Connection check interval
-flush_interval = 30              # Forced buffer flush interval
-log_level = INFO                 # Log level: DEBUG, INFO, WARNING, ERROR
+buffer_size = 100                 # Rows buffered before a batched write
+format = csv                      # Output format: csv or json (currently informational; batcher writes CSV)
+silent_mode = false                # Silent operation (also auto-selects devices)
+auto_select = false                # Auto-select all discovered devices, skip the prompt
 ```
 
 ### Environment Variables
 
-Override any configuration setting with environment variables:
+Override select settings with environment variables (read in `load_config()`):
 
 ```bash
 export CSV_LOG_INTERVAL=0.5
 export CSV_LOG_OUTPUT_DIR=/var/log/benchlab
+export CSV_LOG_BUFFER_SIZE=200
 export CSV_LOG_SILENT=true
 export CSV_LOG_AUTO_SELECT=true
-export CSV_LOG_FORMAT=json
 ```
+
+`BENCHLAB_AUTO_SELECT=true` is also honored by `run_enhanced_csv_logger()` (used when launched via `python -m benchlab -logfleet`) to force auto-selection.
 
 ---
 
@@ -87,274 +80,94 @@ export CSV_LOG_FORMAT=json
 
 ### Command Line Interface
 
+Via the main BENCHLAB launcher (recommended):
+
 ```bash
-# Basic usage with default settings
-python benchlab/csv_log/csv_logger_enhanced.py
+# Basic usage with default settings (direct/serial source, 1s interval)
+python -m benchlab -logfleet
 
-# Custom interval and config file
-python benchlab/csv_log/csv_logger_enhanced.py -i 0.5 -c my_config.config
+# Custom interval
+python -m benchlab -logfleet -i 0.5
 
-# Silent mode with auto-selection
-python benchlab/csv_log/csv_logger_enhanced.py --silent --auto-select
+# Choose a data source (direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http)
+python -m benchlab -logfleet --source fastapi --api-url http://127.0.0.1:8000
+python -m benchlab -logfleet --source mqtt --mqtt-broker localhost --mqtt-port 1883
+```
+
+`-i`/`--interval`, `--source`, `--api-url`, `--api-port`, `--mqtt-broker`, and `--mqtt-port` are the standard `benchlab/main.py` CLI flags; the tool itself has no `-logfleet`-specific flags beyond what `main.py` exposes.
+
+Running the module standalone (bypasses the main launcher, uses its own small argparse CLI limited to `direct`/`fastapi`/`mqtt` sources):
+
+```bash
+python -m benchlab.csv_log.csv_logger_enhanced -i 0.5 -c my_config.config
+python -m benchlab.csv_log.csv_logger_enhanced --silent --auto-select
 ```
 
 ### Programmatic Usage
 
 ```python
 from benchlab.csv_log.csv_logger_enhanced import EnhancedCSVLogger, LoggerConfig
+import types
 
 # Create configuration
 config = LoggerConfig(
     interval=0.5,
     output_dir="custom_logs",
     buffer_size=50,
-    format="json",
-    silent_mode=True
+    silent_mode=True,
+    auto_select=True,
 )
 
-# Create and run logger
-logger = EnhancedCSVLogger(config)
-logger.start_logging()
+# args mirrors the standard benchlab CLI namespace (source/api_url/mqtt_broker/mqtt_port)
+args = types.SimpleNamespace(source="direct", interval=0.5, api_url="http://127.0.0.1:8000",
+                              mqtt_broker="localhost", mqtt_port=1883)
+
+# Create and run logger (use as a context manager so stop_logging() always runs)
+with EnhancedCSVLogger(config, args=args) as logger:
+    logger.start_logging()
 ```
 
 ---
 
-## Output Formats
+## Output Format
 
-### CSV Format (Default)
+Rows are written as CSV via the batching logger (`benchlab/csv_log/message_batcher.py`):
 
 ```
-Timestamp,SYS_Power,CPU_Power,GPU_Power,Temp1,Temp2,...
-2025-10-06T10:15:01.123456,120,50,30,65,70,...
-2025-10-06T10:15:02.123456,118,49,31,65,71,...
+Timestamp,uid,SYS_Power,CPU_Power,GPU_Power,Temp1,Temp2,...
+2025-10-06T10:15:01.123456,BL-1234,120,50,30,65,70,...
+2025-10-06T10:15:02.123456,BL-1234,118,49,31,65,71,...
 ```
 
-### JSON Format
-
-```json
-{"Timestamp": "2025-10-06T10:15:01.123456", "SYS_Power": 120, "CPU_Power": 50, "GPU_Power": 30, "Temp1": 65, "Temp2": 70}
-{"Timestamp": "2025-10-06T10:15:02.123456", "SYS_Power": 118, "CPU_Power": 49, "GPU_Power": 31, "Temp1": 65, "Temp2": 71}
-```
+The `format` config key is accepted by `LoggerConfig` but the batcher currently always writes CSV; JSON output is not implemented.
 
 ---
 
-## Performance Optimizations
+## Behavior Notes
 
-### Buffered Writes
-
-The logger uses configurable buffering to optimize disk I/O:
-
-- **Buffer Size**: Configurable number of rows before writing to disk
-- **Forced Flush**: Automatic flush at regular intervals
-- **Memory Management**: Circular buffers prevent memory leaks
-
-### Connection Monitoring
-
-- **Auto-reconnection**: Automatically reconnects to dropped devices
-- **Connection Health**: Monitors connection status every 5 seconds
-- **Device Verification**: Ensures reconnected device is the same
-
-### Error Recovery
-
-- **Exponential Backoff**: Smart retry logic with increasing delays
-- **Graceful Degradation**: Continues logging other devices if one fails
-- **Detailed Logging**: Comprehensive error reporting for debugging
-
----
-
-## Cross-Platform Compatibility
-
-### Windows Optimizations
-
-- **Serial Port Detection**: Handles COM port naming conventions
-- **File System**: Optimized for NTFS performance characteristics
-- **Memory Management**: Windows-specific memory cleanup
-
-### Linux Optimizations
-
-- **Device Detection**: Enhanced /dev/tty* port detection
-- **File System**: Optimized for ext4 and other Linux filesystems
-- **Process Management**: Better resource cleanup on exit
-
-### Embedded Systems
-
-- **Memory Efficiency**: Minimal memory footprint
-- **CPU Optimization**: Reduced CPU usage for long-running processes
-- **Storage Optimization**: Efficient use of limited storage space
-
----
-
-## Advanced Configuration
-
-### High-Frequency Logging
-
-For applications requiring high-frequency data collection:
-
-```ini
-[logger]
-interval = 0.1                    # 10Hz logging
-buffer_size = 1000               # Larger buffer
-output_dir = /tmp/benchlab_logs  # Fast storage
-format = json                    # Faster writes
-```
-
-### Long-Term Monitoring
-
-For extended monitoring with automatic cleanup:
-
-```ini
-[logger]
-interval = 5.0                   # 5-second intervals
-output_dir = /var/log/benchlab   # System log directory
-buffer_size = 50                 # Smaller buffer for timely writes
-max_file_size = 52428800         # 50MB file limit
-```
-
-### Production Deployment
-
-For production environments with multiple devices:
-
-```ini
-[logger]
-silent_mode = true              # No console output
-auto_select = true              # Auto-select all devices
-retry_attempts = 10             # More retry attempts
-retry_delay = 2.0               # Longer initial delay
-log_level = WARNING             # Reduce log verbosity
-
-[advanced]
-enable_monitoring = true        # Enable connection monitoring
-monitor_interval = 10           # Less frequent monitoring
-flush_interval = 60             # Longer flush intervals
-```
-
----
-
-## Monitoring and Diagnostics
-
-### Log Levels
-
-- **DEBUG**: Detailed operation logs (high verbosity)
-- **INFO**: Standard operation logs (default)
-- **WARNING**: Non-critical issues and warnings
-- **ERROR**: Critical errors that affect operation
-
-### Performance Metrics
-
-The logger provides built-in performance monitoring:
-
-- **Write Speed**: Average time per write operation
-- **Memory Usage**: Current buffer memory usage
-- **Connection Status**: Real-time connection health
-- **Error Rates**: Frequency of connection and write errors
-
-### Health Checks
-
-Monitor logger health with these indicators:
-
-- **Buffer Status**: Current buffer fill level
-- **Connection Count**: Number of active device connections
-- **Write Success Rate**: Percentage of successful writes
-- **Memory Usage**: Current memory consumption
+- **Buffered writes**: rows are batched (default `buffer_size = 100`) and flushed via `BatchingLogger`, with a background flush every 5 seconds and an explicit flush each polling cycle.
+- **Retry on connect**: initial connection to the data source uses `SmartRetryManager` (3 attempts, exponential backoff) — see `benchlab/csv_log/smart_retry.py`.
+- **Silent/auto-select**: `silent_mode` or `auto_select` (or `BENCHLAB_AUTO_SELECT=true`) skip the interactive device-selection prompt and log at `WARNING` level instead of `INFO`.
+- **Graceful shutdown**: Ctrl+C stops the polling loop, flushes the batcher, and disconnects the data source (`EnhancedCSVLogger.stop_logging()`).
 
 ---
 
 ## Troubleshooting
 
-### Common Issues
-
-#### Device Not Detected
+### Device Not Detected
 ```bash
-# Check if device is connected
 python -c "from benchlab_pycore.core import get_benchlab_ports; print(get_benchlab_ports())"
-
-# Increase retry attempts in config
-retry_attempts = 10
-retry_delay = 2.0
 ```
 
-#### Permission Errors (Linux)
+### Permission Errors (Linux)
 ```bash
 # Add user to dialout group for serial access
 sudo usermod -a -G dialout $USER
 # Log out and back in, or restart
 ```
 
-#### High Memory Usage
-```ini
-# Reduce buffer size
-buffer_size = 50
-
-# Enable more frequent flushing
-flush_interval = 10
-```
-
-#### Slow Write Performance
-```ini
-# Use JSON format for faster writes
-format = json
-
-# Increase buffer size
-buffer_size = 500
-
-# Use faster storage
-output_dir = /tmp/logs
-```
-
-### Debug Mode
-
-Enable debug mode for detailed troubleshooting:
-
-```ini
-[advanced]
-debug_mode = true
-log_level = DEBUG
-```
-
----
-
-## Integration Examples
-
-### Docker Deployment
-
-```dockerfile
-FROM python:3.9-slim
-
-WORKDIR /app
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-COPY . .
-CMD ["python", "benchlab/csv_log/csv_logger_enhanced.py", "--silent", "--auto-select"]
-```
-
-### Systemd Service (Linux)
-
-```ini
-[Unit]
-Description=BENCHLAB CSV Logger
-After=multi-user.target
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/python3 /opt/benchlab/benchlab/csv_log/csv_logger_enhanced.py --silent --auto-select
-Restart=always
-RestartSec=10
-User=benchlab
-Group=benchlab
-
-[Install]
-WantedBy=multi-user.target
-```
-
-### Windows Service
-
-Use NSSM (Non-Sucking Service Manager) to run as a Windows service:
-
-```bash
-nssm install BenchlabCSVLogger "C:\Python39\python.exe" "C:\benchlab\benchlab\csv_log\csv_logger_enhanced.py" --silent --auto-select
-nssm start BenchlabCSVLogger
-```
+### No devices selected / logging exits immediately
+Ensure the configured `--source` (direct/fastapi/mqtt/etc.) is actually running and reachable — the logger connects via `DataSourceManager`, and a failed connection or empty device discovery causes it to log an error and stop.
 
 ---
 
@@ -364,12 +177,13 @@ nssm start BenchlabCSVLogger
 
 ```python
 class EnhancedCSVLogger:
-    def __init__(self, config: LoggerConfig)
+    def __init__(self, config: LoggerConfig, args=None)
     def start_logging(self)
-    def stop_logging(self, connections: Dict[str, serial.Serial])
+    def stop_logging(self)
     def discover_devices(self) -> List[DeviceConfig]
     def select_devices(self, devices: List[DeviceConfig]) -> List[DeviceConfig]
-    def open_connections(self, devices: List[DeviceConfig]) -> Dict[str, serial.Serial]
+    def create_batcher(self)
+    def log_device_data(self, uid: str) -> bool
 ```
 
 ### LoggerConfig Dataclass
@@ -380,51 +194,13 @@ class LoggerConfig:
     interval: float = 1.0
     output_dir: str = "logs"
     buffer_size: int = 100
-    max_file_size: int = 100 * 1024 * 1024
-    retry_attempts: int = 3
-    retry_delay: float = 1.0
-    format: str = "csv"
-    timestamp_format: str = "%Y-%m-%d %H:%M:%S.%f"
+    format: str = "csv"          # accepted, but only CSV output is implemented
     silent_mode: bool = False
     auto_select: bool = False
 ```
 
 ---
 
-## Performance Benchmarks
-
-### Memory Usage
-- **Base Memory**: ~10MB startup
-- **Per Device**: ~1MB additional memory
-- **Buffer Memory**: Configurable (default 100 rows ≈ 50KB)
-
-### Write Performance
-- **CSV Format**: ~1000 rows/second
-- **JSON Format**: ~1500 rows/second
-- **Buffered Writes**: 10x performance improvement
-
-### Connection Performance
-- **Discovery Time**: ~2-5 seconds for 10 devices
-- **Reconnection Time**: ~1-3 seconds average
-- **Monitoring Overhead**: <1% CPU usage
-
----
-
-## Future Enhancements
-
-- **Database Export**: Direct export to SQLite, PostgreSQL
-- **Compression**: Automatic gzip compression for long-term storage
-- **Web Interface**: Web-based configuration and monitoring
-- **Alerting**: Email/SMS alerts for device disconnections
-- **Metrics Export**: Prometheus/Grafana integration
-- **Cloud Storage**: Direct upload to cloud storage services
-
----
-
 ## Support
 
-For issues and support:
-- Check the troubleshooting section above
-- Enable debug mode for detailed logs
-- Report bugs via GitHub issues
-- Join our community forum for discussions
+For issues, check the Troubleshooting section above or report bugs via GitHub issues.

--- a/benchlab/graph/README.md
+++ b/benchlab/graph/README.md
@@ -28,16 +28,16 @@ Built using [Dear PyGui](https://dearpygui.readthedocs.io/), the module supports
 
 ## Installation
 
-Install the required dependencies:
+Install the tool's dependencies (from `benchlab/graph/requirements.txt`):
 
 ```
-pip install -r requirements_graph.txt
+pip install -r benchlab/graph/requirements.txt
 ```
 
-**Dependencies include:**
+**Dependencies:**
 
-- `dearpygui`
-- `numpy` (optional, if used in advanced calculations)
+- `dearpygui>=2.1.1`
+- `pyserial>=3.5`
 - BENCHLAB core modules (`benchlab.core`)
 
 ---
@@ -48,9 +48,19 @@ pip install -r requirements_graph.txt
 
 From the main BENCHLAB launcher:
 
+```bash
+# Default (direct/serial source, 1s sensor poll interval)
+python -m benchlab -graph
+
+# Custom interval
+python -m benchlab -graph -i 0.5
+
+# Choose a data source (direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http)
+python -m benchlab -graph --source fastapi --api-url http://127.0.0.1:8000
+python -m benchlab -graph --source mqtt --mqtt-broker localhost --mqtt-port 1883
 ```
-python benchlab.py -graph
-```
+
+`-i`/`--interval` sets `GraphApp.sensor_read_interval` (default 1.0s). `--source`, `--api-url`, `--mqtt-broker`, and `--mqtt-port` are the standard `benchlab/main.py` flags; the graph module has no `-graph`-specific CLI flags of its own.
 
 ### Main GUI
 

--- a/benchlab/hwinfo/README.md
+++ b/benchlab/hwinfo/README.md
@@ -1,8 +1,10 @@
 # BenchLab HWiNFO Exporter
 
-**benchlab/hwinfo_export.py** is a Python utility that bridges BenchLab telemetry data with **HWiNFO64**’s custom sensor interface. It exports live sensor data (temperature, voltage, current, power, fan speed, and more) directly into HWiNFO’s registry-based “Custom” sensors section.
+**benchlab/hwinfo/hwinfo_export.py** (flag: `-hwinfo`) is a Python utility that bridges BenchLab telemetry data with **HWiNFO64**'s custom sensor interface. It exports live sensor data (temperature, voltage, current, power, fan speed, and more) directly into HWiNFO's registry-based "Custom" sensors section.
 
 This allows seamless integration of BenchLab devices with the HWiNFO monitoring and logging ecosystem.
+
+**Windows only** — the tool uses the `winreg` module and raises a `RuntimeError` on start if not run on Windows (`sys.platform` does not start with `win`).
 
 ---
 
@@ -61,26 +63,50 @@ During runtime or on exit:
 
 ## Requirements
 
-- **Windows** (uses `winreg`)
+- **Windows** (uses `winreg`) — the tool refuses to run on other platforms
 - **HWiNFO64** installed (for reading custom sensors)
 - **Python 3.8+**
-- BenchLab Core library available (providing `serial_io`, `sensor_translation`, etc.)
+- `benchlab-pycore` (device protocol) and `pyserial` — see Installation below
+
+---
+
+## Installation
+
+Install the tool's dependencies (from `benchlab/hwinfo/requirements.txt`):
+
+```bash
+pip install -r benchlab/hwinfo/requirements.txt
+```
+
+Key dependency: `pyserial>=3.5` (plus `benchlab-pycore`, already required by the main package).
 
 ---
 
 ## Usage
 
-Run the exporter from the BenchLab project directory:
+Run the exporter from the BenchLab project directory via the main launcher:
 
-python benchlab.py -hwinfo
+```bash
+# Default (direct/serial source, 1s update interval)
+python -m benchlab -hwinfo
 
+# Custom interval
+python -m benchlab -hwinfo -i 2
+
+# Choose a data source (direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http)
+python -m benchlab -hwinfo --source fastapi --api-url http://127.0.0.1:8000
+python -m benchlab -hwinfo --source mqtt --mqtt-broker localhost --mqtt-port 1883
+```
+
+`-i`/`--interval` controls `update_interval` (seconds between export cycles, default 1). `--source`, `--api-url`, `--mqtt-broker`, and `--mqtt-port` are the standard `benchlab/main.py` flags — the exporter has no `-hwinfo`-specific CLI flags of its own; all sources are supported (no `supported_sources` restriction in `benchlab/tools.py`).
 
 It will:
-1. Enumerate connected BenchLab devices
+1. Enumerate connected BenchLab devices via the selected data source
 2. Continuously update sensor data in the registry
-3. Make readings available in HWiNFO’s Custom Sensors section
+3. Make readings available in HWiNFO's Custom Sensors section
+4. Remove registry entries for any device that drops out of the fleet
 
-Press **Ctrl+C** to stop. The script cleans up its registry keys automatically.
+Press **Ctrl+C** to stop. The script cleans up its registry keys automatically (`cleanup_registry()` is also registered via `atexit`).
 
 ---
 

--- a/benchlab/link/README.md
+++ b/benchlab/link/README.md
@@ -1,0 +1,172 @@
+# BENCHLAB Link
+
+## Overview
+
+Benchlab Link is a cloud MQTT publisher. It reads telemetry from any local BENCHLAB data source (direct serial, FastAPI, or MQTT) and republishes it as JSON to a remote/cloud MQTT broker — typically BENCHLAB's SaaS broker, for dashboards, fleet monitoring, or other cloud consumers.
+
+It automatically:
+
+- Connects to a local data source via `DataSourceManager` (direct / fastapi / fastapi_custom / mqtt).
+- Polls each discovered device's telemetry snapshot on a background thread.
+- Publishes a JSON payload per device to the remote broker on a configurable interval.
+- Supports TLS and WebSocket transport for the remote connection.
+- Reconnects automatically if the remote broker connection drops.
+- Handles graceful shutdown on Ctrl+C.
+
+## Features
+
+| Feature | Description |
+|---|---|
+| Local source flexibility | Works with any `--source` supported by the rest of the suite (direct, fastapi, fastapi_custom, mqtt). |
+| Cloud MQTT publishing | Publishes one topic per device, built from a configurable `{uid}` topic pattern. |
+| TLS / WebSocket support | Connects over `websockets` (default) or `tcp` transport, with TLS enabled by default. |
+| Auto-reconnect | If the cloud broker connection drops, Link retries every 5 seconds using a fresh client. |
+| Layered configuration | CLI args > environment variables > `.env` file > `link.config` JSON file > built-in defaults. |
+| Graceful shutdown | Stops the poller thread, disconnects from both the local source and the cloud broker on Ctrl+C. |
+
+## Installation
+
+Link is included in BENCHLAB PyTools. It requires `paho-mqtt` (already a dependency of the suite) and whatever the chosen local `--source` requires (e.g. `benchlab-pycore` for `direct`, `requests` for `fastapi`).
+
+## Usage
+
+Run via the main launcher:
+
+```bash
+python -m benchlab -link
+```
+
+By default this connects to the local `direct` data source and publishes to the remote host configured via env/config (see Configuration below). Combine with the usual `--source` flags to choose a different local source:
+
+```bash
+# Read telemetry from a local FastAPI server instead of direct serial
+python -m benchlab -link --source fastapi --api-url http://127.0.0.1:8000
+
+# Read telemetry from local MQTT
+python -m benchlab -link --source mqtt --mqtt-broker localhost --mqtt-port 1883
+```
+
+Cloud connection settings can be passed directly on the command line, overriding any env var / `.env` / `link.config` value:
+
+```bash
+python -m benchlab -link \
+  --remote-host mqtt.benchlab.io \
+  --remote-port 443 \
+  --remote-user my-device-id \
+  --remote-pass "my-secret" \
+  --topic-pattern "benchlab/{uid}/telemetry"
+
+# Disable TLS (e.g. for a local test broker)
+python -m benchlab -link --remote-host localhost --remote-port 1883 --no-tls
+```
+
+CLI flags (from `benchlab/main.py`):
+
+| Flag | Description |
+|---|---|
+| `-link` | Run the cloud MQTT link publisher |
+| `--remote-host` | Cloud MQTT broker hostname (overrides `REMOTE_MQTT_HOST`) |
+| `--remote-port` | Cloud MQTT broker port (default: 443) |
+| `--remote-user` | Cloud MQTT username (overrides `REMOTE_MQTT_USER`) |
+| `--remote-pass` | Cloud MQTT password (overrides `REMOTE_MQTT_PASS`) |
+| `--no-tls` | Disable TLS for the cloud MQTT connection |
+| `--topic-pattern` | MQTT topic pattern with a `{uid}` token (overrides `LINK_TOPIC_PATTERN`) |
+| `--source` | Local data source: `direct` \| `fastapi` \| `fastapi_custom` \| `mqtt` \| `mqtt_custom` |
+| `--api-url` | FastAPI base URL, when `--source fastapi`/`fastapi_custom` |
+| `--mqtt-broker`, `--mqtt-port` | Local MQTT broker, when `--source mqtt`/`mqtt_custom` |
+
+You can also run the module directly with a pre-built `argparse.Namespace` (as `run_link(args)` is called from `main.py`), or invoke `python -m benchlab.link.link_main` to use env-var-only defaults (`BENCHLAB_DATA_SOURCE`, `MQTT_POLL_RATE`, `BENCHLAB_API_URL`, `MQTT_BROKER`, `MQTT_PORT`).
+
+## Configuration
+
+Configuration is resolved with this priority (highest first):
+
+1. CLI args (`--remote-host`, `--no-tls`, etc. — mirrored into env vars by `main.py`'s `_export_link_env()`)
+2. Environment variables
+3. `.env` file in `benchlab/link/` (only sets a var if it isn't already set in the environment)
+4. `link.config` JSON file (`benchlab/link/link.config` by default, or `LINK_CONFIG_PATH`)
+5. Built-in defaults
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `REMOTE_MQTT_HOST` | *(none — required)* | Cloud MQTT broker hostname |
+| `REMOTE_MQTT_PORT` | `443` | Cloud MQTT broker port |
+| `REMOTE_MQTT_USER` | *(none)* | MQTT username |
+| `REMOTE_MQTT_PASS` | *(none)* | MQTT password |
+| `REMOTE_MQTT_PATH` | `/mqtt` | WebSocket path (used when transport is `websockets`) |
+| `REMOTE_MQTT_TRANSPORT` | `websockets` | Transport: `websockets` or `tcp` |
+| `REMOTE_MQTT_PROTOCOL` | `mqtt.MQTTv5` | MQTT protocol version string; `"5"` in the value selects `MQTTv5`, anything else selects `MQTTv311` |
+| `REMOTE_MQTT_QOS` | `1` | QoS level: 0, 1, or 2 |
+| `REMOTE_MQTT_TLS` | `true` | Enable TLS. Set to `false`/`0`/`no` to disable |
+| `CLIENT_UUID` | *(none)* | Device UUID, used to build the default MQTT client ID |
+| `MQTT_POLL_RATE` | `2` | Poll/publish interval in seconds |
+| `LINK_TOPIC_PATTERN` | `benchlab/{uid}/telemetry` | Topic pattern; `{uid}` is replaced with the device's UID for each publish |
+| `LINK_CLIENT_ID` | `benchlab-link-<uuid-or-hostname>` | MQTT client ID sent to the broker |
+| `LINK_CONFIG_PATH` | `benchlab/link/link.config` | Override path to the JSON config file |
+
+### `.env` file
+
+Place a `.env` file in `benchlab/link/` with `KEY=VALUE` pairs — copy `.env.EXAMPLE` as a starting point:
+
+```
+REMOTE_MQTT_HOST=mqtt.benchlab.io
+REMOTE_MQTT_PORT=443
+REMOTE_MQTT_PATH=/mqtt
+REMOTE_MQTT_TRANSPORT=websockets
+REMOTE_MQTT_PROTOCOL=mqtt.MQTTv5
+REMOTE_MQTT_QOS=1
+REMOTE_MQTT_USER=mqtt_user
+REMOTE_MQTT_PASS=mqtt_pass
+CLIENT_UUID=client_uuid
+MQTT_POLL_RATE=2
+```
+
+`.env` values only take effect if the corresponding environment variable is not already set (i.e. they are a fallback, not an override).
+
+### `link.config` JSON file
+
+`benchlab/link/link.config` uses the same settings under snake_case keys:
+
+```json
+{
+  "remote_host":      "mqtt.benchlab.io",
+  "remote_port":      443,
+  "remote_user":      "test-device-001",
+  "remote_pass":      "your-mqtt-password",
+  "remote_tls":       true,
+  "topic_pattern":    "benchlab/{uid}/telemetry",
+  "publish_interval": 1.0,
+  "client_id":        "your-client-uuid"
+}
+```
+
+This file is loaded only as a fallback below env vars/`.env`/CLI args — the checked-in `link.config` in this repo ships with example/placeholder credentials and is meant to be edited locally, not used as-is in production.
+
+### Topic pattern
+
+`topic_pattern` (default `benchlab/{uid}/telemetry`) is formatted per-device with `.format(uid=uid)`, so `{uid}` is the only supported token. Published payloads are `{"uid": <uid>, ...telemetry fields...}`.
+
+## Troubleshooting
+
+**"No remote MQTT host configured"** — `REMOTE_MQTT_HOST` (or `remote_host` in `link.config`, or `--remote-host`) is not set. Link exits immediately without a host.
+
+**"Failed to connect to `<source>` datasource"** — the local data source (direct/fastapi/mqtt) could not be reached. Verify the device is connected (for `direct`) or the FastAPI/MQTT service is running and reachable at the configured URL/broker.
+
+**"Cloud broker disconnected — retrying in 5s"** — the connection to the remote broker dropped; Link automatically reconnects with a fresh client every 5 seconds. Check network connectivity and credentials if this repeats continuously.
+
+**Connection timeout to cloud broker** — verify `REMOTE_MQTT_PORT` matches the transport (443/`websockets`+TLS is typical for BENCHLAB's cloud broker; local test brokers are often 1883/`tcp` with `--no-tls`), and that `REMOTE_MQTT_PATH` is correct when using `websockets` transport.
+
+**Nothing gets published** — Link only publishes devices it currently has a telemetry snapshot for. Confirm the local data source's `list_devices()`/`snapshot()` calls are returning data; check the local source is healthy first (e.g. hit the FastAPI server's `/health` endpoint) before troubleshooting Link itself.
+
+## See Also
+
+- [BENCHLAB PyTools Documentation](../../README.md) - Main PyTools documentation
+- [BENCHLAB Core README](../core/README.md) - `DataSourceManager` and the data source abstraction Link consumes
+- [MQTT Publisher README](../mqtt/README.md) - the local MQTT source Link can read from
+- [FastAPI Telemetry Server README](../restapi/readme.md) - the local FastAPI source Link can read from
+
+## License
+
+Part of BENCHLAB PyTools. See main project license for details.

--- a/benchlab/mqtt/README.md
+++ b/benchlab/mqtt/README.md
@@ -39,13 +39,15 @@ Install the required dependencies for the MQTT module:
 pip install -r requirements.txt
 ```
 
-Dependencies include:
+Dependencies (see `requirements.txt`):
 
 ```
-paho-mqtt
-pyserial
-benchlab core modules
+paho-mqtt>=1.6.1
+amqtt>=0.12.0,<0.13.0
+pyyaml>=6.0,<7.0
 ```
+
+Plus the `benchlab_pycore` core modules and the rest of the `benchlab` package (installed as part of the overall project).
 
 ---
 
@@ -99,8 +101,16 @@ poll_rate = 0.5
 ### Run MQTT Mode
 
 ```
-python benchlab.py -mqtt
+python -m benchlab -mqtt
 ```
+
+`-mqtt` takes an optional positional broker hostname. If omitted, it defaults to `localhost`:
+
+```
+python -m benchlab -mqtt mybroker.local
+```
+
+The broker hostname can also be set via the `MQTT_BROKER` environment variable, or overridden with `--mqtt-broker`/`--mqtt-port` (used when this tool is launched together with other tools that consume the same MQTT source, e.g. via `--source mqtt`).
 
 Behavior:
 
@@ -188,5 +198,4 @@ Payload:
 
 ## References
 
-- [Paho-MQTT Python client](https://pypi.org/project/paho-mqtt/)  
-- [Benchlab core modules](https://github.com/<your-org>/benchlab/tree/main/benchlab/core)
+- [Paho-MQTT Python client](https://pypi.org/project/paho-mqtt/)

--- a/benchlab/restapi/readme.md
+++ b/benchlab/restapi/readme.md
@@ -27,48 +27,49 @@ A lightweight, cross-platform REST API server for BenchLab telemetry data collec
 
 ### 1. Installation
 ```bash
-cd benchlab/fastapi
 pip install -r requirements.txt
 ```
 
 ### 2. Configuration
-Copy the example configuration and customize as needed:
-```bash
-cp .env.example .env
-```
-
-Edit `.env` to configure:
-- Server host and port
-- Polling intervals
-- History buffer size
-- Log levels
+Optionally create a `.env` file in `benchlab/restapi/` to override defaults (see Configuration Options below). All settings also work as plain environment variables.
 
 ### 3. Run the Server
+```bash
+python -m benchlab -fastapi
+```
+
+You can also run the module directly:
 ```bash
 python -m benchlab.restapi.telemetry_api
 ```
 
-The server will start on `http://localhost:8000` by default.
+The server will start on `http://0.0.0.0:8000` by default (configurable via `API_HOST`/`API_PORT`).
 
 ## API Endpoints
 
 ### Device Management
-- `GET /devices` - List all connected devices
-- `GET /device/{uid}/info` - Get device information
-- `GET /device/{uid}/status` - Get detailed device status
+- `GET /devices` - List all connected devices (uid, port, firmware, variant, VendorId, ProductId, connected)
+- `GET /device/{uid}/info` - Get device information (returns mock info with 404-style defaults if the uid isn't known, for test convenience)
+- `GET /device/{uid}/status` - Get detailed status for a specific device (port, connected, last_update, client_count, history_count, latest_telemetry, info)
+- `POST /scan` - Trigger an immediate device scan (discovers new devices, marks disconnected ones) without restarting the server
 
 ### Telemetry Data
-- `GET /device/{uid}/telemetry` - Get latest telemetry
-- `GET /device/{uid}/telemetry/{sensor}` - Get specific sensor data
-- `GET /device/{uid}/history` - Get telemetry history (with pagination)
-- `GET /device/{uid}/sensors` - List available sensors
+- `GET /device/{uid}/telemetry` - Get latest telemetry snapshot for a device
+- `GET /device/{uid}/telemetry/{sensor}` - Get a single sensor's latest value
+- `GET /device/{uid}/history?limit=100` - Get telemetry history (most recent `limit` entries, capped by `MAX_HISTORY_LIMIT`); response includes `device_id`, `data`, `count`, `total_available`
+- `GET /device/{uid}/sensors` - List available sensor keys for a device
 
 ### Real-time Streaming
-- `WebSocket /device/{uid}/stream` - Real-time telemetry updates
+- `WebSocket /device/{uid}/stream` - Real-time telemetry updates, pushed as each device's reader thread reads new sensor data
 
 ### Monitoring
-- `GET /health` - Basic health check
-- `GET /status` - Detailed server status
+- `GET /health` - Basic health check (status, platform, timestamp, connected_devices, total_clients)
+- `GET /status` - Detailed server status for all devices
+- `GET /favicon.ico` - Server favicon
+
+All endpoints for an unknown `{uid}` return `404` (except `/device/{uid}/info`, which returns mock placeholder data instead).
+
+A background scanner thread re-scans for new/disconnected devices every `SCAN_INTERVAL` seconds automatically, in addition to the manual `POST /scan` endpoint.
 
 ## Configuration Options
 
@@ -81,6 +82,7 @@ The server will start on `http://localhost:8000` by default.
 | `HISTORY_LENGTH` | `10` | Number of history entries per device |
 | `MAX_HISTORY_LIMIT` | `1000` | Max history limit for API requests |
 | `SCAN_INTERVAL` | `30` | Device discovery scan interval in seconds |
+| `CORS_ORIGINS` | `*` | Comma-separated allowed CORS origins. Credentialed requests are only allowed when explicit origins are set (wildcard + credentials is rejected by browsers) |
 
 ## Cross-Platform Support
 
@@ -94,7 +96,7 @@ The server automatically detects and works with BenchLab devices across differen
 
 Run the test suite to verify the server functionality:
 ```bash
-python test_server.py
+python -m pytest benchlab/restapi/test_server.py
 ```
 
 This tests:
@@ -179,7 +181,7 @@ WantedBy=multi-user.target
 ### Logging
 Enable debug logging for troubleshooting:
 ```bash
-LOG_LEVEL=DEBUG python -m benchlab.restapi.telemetry_api
+LOG_LEVEL=DEBUG python -m benchlab -fastapi
 ```
 
 ## Development

--- a/benchlab/tui/README.md
+++ b/benchlab/tui/README.md
@@ -33,6 +33,8 @@ The BENCHLAB Enhanced TUI provides a modern, feature-rich curses-based interface
 
 ## 📊 Telemetry Tabs
 
+The TUI has 8 tabs: `Fleet`, `Device`, `System`, `Motherboard`, `12VHPWR`, `Voltage`, `Temperature`, `Fans` (in this order; see `Config.TAB_NAMES` in `benchlab/tui/config.py`). Tabs can also be jumped to directly with the number keys `0`-`7`.
+
 ### **Fleet Tab (Tab 0)**
 - Device list with connection status indicators
 - Active device highlighting
@@ -45,21 +47,21 @@ The BENCHLAB Enhanced TUI provides a modern, feature-rich curses-based interface
 - Firmware version display
 - TUI refresh interval
 
-### **Power Tab (Tab 2)**
+### **System / Motherboard / 12VHPWR Tabs (Tabs 2-4)**
 - Real-time power consumption with progress bars
-- Individual component power monitoring (SYS, CPU, GPU, MB)
+- Component power monitoring, split across dedicated System, Motherboard, and 12VHPWR tabs
 - Efficiency calculations and display
 - Min/max power statistics
 - Power progress bars with color coding
 
-### **Voltage Tab (Tab 3)**
+### **Voltage Tab (Tab 5)**
 - Vdd and Vref voltage monitoring with status
 - VIN channel voltage display with progress bars
 - Voltage status indicators (OK/LOW/HIGH)
 - Average voltage calculations
 - Color-coded voltage readings
 
-### **Temperature Tab (Tab 4)**
+### **Temperature Tab (Tab 6)**
 - Chip and ambient temperature monitoring
 - Temperature progress bars with thermal status
 - Multiple temperature sensor readings
@@ -67,7 +69,7 @@ The BENCHLAB Enhanced TUI provides a modern, feature-rich curses-based interface
 - Thermal status classification (NORMAL/WARNING/CRITICAL)
 - Min/max temperature statistics
 
-### **Fans Tab (Tab 5)**
+### **Fans Tab (Tab 7)**
 - Fan duty cycle monitoring with progress bars
 - RPM readings for each fan
 - Fan enable/disable status
@@ -77,10 +79,11 @@ The BENCHLAB Enhanced TUI provides a modern, feature-rich curses-based interface
 ## 🎮 Keyboard Shortcuts
 
 ### **Navigation**
-- `h`, `k`, `←`, `↑` - Move to previous tab
-- `l`, `j`, `→`, `↓` - Move to next tab
+- `h`, `←` - Move to previous tab
+- `l`, `→` - Move to next tab
+- `0`-`7` - Jump directly to a tab by index
 - `q`, `Q` - Quit application
-- `?` - Show help
+- `?` - Show/hide help modal
 
 ### **Fleet Tab Specific**
 - `↑`, `↓` - Navigate device list
@@ -88,6 +91,9 @@ The BENCHLAB Enhanced TUI provides a modern, feature-rich curses-based interface
 
 ### **Global Commands**
 - `r`, `R` - Reset min/max statistics
+- `f` - Rescan the fleet for devices
+
+Note: navigation is arrow-key and `h`/`l` only — there is no vim-style `j`/`k` tab switching or full vim keybinding scheme.
 
 ## 🎨 Color Coding
 
@@ -133,23 +139,35 @@ Ensure your environment has required dependencies:
 pip install -r requirements.txt
 ```
 
-Dependencies include:
-- `python3-curses` (Linux/Unix)
-- `benchlab core modules`
+Dependencies (see `requirements.txt`):
+- `pyserial>=3.5`
+- `windows-curses>=2.4.1` (Windows only — the Python standard library's `curses` module isn't available on Windows, so this package provides it)
+
+On Linux/macOS, `curses` ships with the Python standard library, so no extra curses package is needed there.
 
 ## 🚀 Usage
 
 ### Launch the Enhanced TUI
 
 ```bash
-python benchlab.py -tui
+python -m benchlab -tui
 ```
+
+Running `python -m benchlab` with no flags at all also launches the interactive menu, from which the TUI can be selected; `-tui` is otherwise the default consumer tool.
 
 ### Configuration
 
-The TUI supports the same configuration options as the original:
-- `--interval` - Telemetry refresh interval
-- Environment variables for serial connection settings
+- `-i`, `--interval` - Telemetry refresh interval in seconds (default: `1.0`)
+- `--source` - Data source to read telemetry from: `direct` (serial, default), `fastapi`, `fastapi_custom`, `mqtt`, `named_pipe`, or `service_http`
+- `--api-port` - FastAPI server port, used when `--source fastapi` (default: `8000`)
+- `--mqtt-broker`, `--mqtt-port` - MQTT broker host/port, used when `--source mqtt` (defaults: `localhost` / `1883`)
+- `--service-url` - C# BenchLab service HTTP API URL, used when `--source service_http` (default: `http://localhost:8585`)
+
+Example:
+
+```bash
+python -m benchlab -tui --source fastapi --api-port 8000 --interval 0.5
+```
 
 ## 📋 Requirements
 
@@ -187,7 +205,7 @@ The TUI supports the same configuration options as the original:
 | Statistics | None | Min/max/average tracking |
 | Help System | None | Built-in help modal |
 | Error Handling | Basic | Enhanced with clear indicators |
-| Navigation | Arrow keys only | Vim-style + arrow keys |
+| Navigation | Arrow keys only | Arrow keys + `h`/`l` |
 | Status Indicators | Text only | Color-coded + text |
 | Connection Monitoring | Basic | Uptime + status tracking |
 | Statistics Reset | None | Quick reset functionality |
@@ -218,7 +236,7 @@ The TUI supports the same configuration options as the original:
 ### **Debug Mode**
 Enable debug logging for troubleshooting:
 ```bash
-LOG_LEVEL=DEBUG python benchlab.py -tui
+LOG_LEVEL=DEBUG python -m benchlab -tui
 ```
 
 ## 🔄 Development
@@ -237,9 +255,7 @@ LOG_LEVEL=DEBUG python benchlab.py -tui
 
 ## 📚 References
 
-- [BENCHLAB core modules](https://github.com/<your-org>/benchlab/tree/main/benchlab/core)
 - [Python curses documentation](https://docs.python.org/3/library/curses.html)
-- [Original TUI documentation](README.md)
 
 ## 🤝 Contributing
 

--- a/benchlab/vu/README.md
+++ b/benchlab/vu/README.md
@@ -1,0 +1,64 @@
+# BENCHLAB VU Dials
+
+Drives physical analog-style USB "VU dial" gauges (via the bundled [VU-Server](VU-Server/)) using live BENCHLAB telemetry, and provides a terminal UI for mapping dials to sensors.
+
+## Overview
+
+This tool has two pieces:
+
+- **VU Updater** (`-vu`) — polls BENCHLAB telemetry via the shared data-source layer, resolves each configured dial's mapped sensor value, and pushes it to the VU-Server API so the physical dial needle moves. Also renders and uploads a sensor logo image to each dial's screen.
+- **VU Config** (`-vuconfig`) — a curses TUI (`vu_tui.py`) for discovering connected VU dials and BENCHLAB devices, and mapping each dial to a specific device + sensor.
+
+Both talk to a local **VU-Server** process (bundled in [`VU-Server/`](VU-Server/), a fork of [ThePi910FC's VU1 server](VU-Server/README.md)), which the tool starts and manages automatically if it isn't already running.
+
+## Installation
+
+```bash
+pip install -r benchlab/vu/requirements.txt
+```
+
+Key dependencies: `requests`, `PyYAML`, `Pillow` (logo rendering), `pyserial`, `tornado` (VU-Server), plus `blessed` for the legacy curses-adjacent terminal helpers.
+
+## Usage
+
+### Configure dial-to-sensor mappings
+
+```bash
+python -m benchlab -vuconfig
+```
+
+Lists detected VU dials and BENCHLAB devices/sensors, and lets you assign a sensor to each dial. Mappings are written to `benchlab/vu/vu_dial.config`.
+
+### Run the updater
+
+```bash
+python -m benchlab -vu
+```
+
+Starts (or connects to) VU-Server, then continuously polls telemetry and updates each mapped dial. Supports the standard data-source flags (`--source`, `--api-url`, `--mqtt-broker`, etc. — see the [top-level README](../../README.md#data-sources)) and `-i/--interval` for poll frequency.
+
+The updater watches `vu_dial.config` for changes and hot-reloads mappings without restarting.
+
+## Configuration
+
+- **`vu_server.config`** — VU-Server connection settings:
+  ```json
+  {
+    "vu_server_url": "http://localhost:5340",
+    "api_key": "...",
+    "logo_file": "assets/bl_logo_144x200.png"
+  }
+  ```
+- **`vu_dial.config`** — list of dial-to-sensor mappings (`dial_uid`, `dial_name`, `benchlab_uid`, `benchlab_port`, `sensor`), managed by `-vuconfig` or by editing directly.
+- **`VU-Server/config.yaml`** — the underlying VU-Server's own device/serial configuration.
+
+## Troubleshooting
+
+- **VU-Server won't start** — check `vu_updater.log` in this directory; the updater forwards VU-Server's stdout/stderr there.
+- **No dials detected** — VU dials enumerate as USB serial devices; verify they're connected and recognized by the OS before running `-vuconfig`.
+- **Dial not updating** — confirm the mapped sensor name still exists in the current telemetry snapshot (sensor keys can change if a device's config changes).
+
+## See Also
+
+- [BENCHLAB PyTools Documentation](../../README.md)
+- [VU-Server README](VU-Server/README.md) — the bundled dial server itself

--- a/benchlab/wigidash/README.md
+++ b/benchlab/wigidash/README.md
@@ -110,12 +110,21 @@ wigidash/
 ### Launch the Dashboard
 
 ```
-python benchlab.py -wigidash
+python -m benchlab -wigidash
 ```
+
+By default this connects via the `direct` (serial) data source. To use a different source, pass `--source` along with the matching connection flags:
+
+```
+python -m benchlab -wigidash --source fastapi --api-url http://127.0.0.1:8000
+python -m benchlab -wigidash --source mqtt --mqtt-broker localhost --mqtt-port 1883
+```
+
+Supported `--source` values: `direct`, `fastapi`, `fastapi_custom` (via `DataSourceManager`, same as the other consumer tools).
 
 Behavior:
 
-- Detects all connected BENCHLAB devices.
+- Detects all connected BENCHLAB devices via the selected data source.
 - Displays the main overview page.
 - Allows switching to the telemetry graph page for detailed metrics.
 - Supports interactive metric selection and fan toggles.
@@ -170,4 +179,4 @@ This project is licensed under MIT License. See the LICENSE file for details.
 - [Matplotlib](https://matplotlib.org/)  
 - [NumPy](https://numpy.org/)  
 - [pyserial](https://pypi.org/project/pyserial/)  
-- [pyusb](https://pypi.org/project/pyusb/)  
+- [pyusb](https://pypi.org/project/pyusb/)


### PR DESCRIPTION
Closes #40

## Summary
- Rewrote the top-level `README.md` to match the current entry points (`python -m benchlab` / `python benchlab.py`), the unified data-source model, and launch profiles.
- Audited and corrected per-tool READMEs (csv_log, graph, hwinfo, mqtt, wigidash, tui, restapi, core, config) against actual source — fixed stale invocation examples, wrong/missing CLI flags, and some fabricated content that didn't match the code.
- Added missing READMEs for `link` and `vu`, which previously had none.
- Fixed the `--help` epilog examples in `benchlab/config/config_tool.py` to match the corrected docs.

## Test plan
- [x] Skim each README against its corresponding module for accuracy — spot-checked restapi endpoints (all 10 HTTP routes + websocket `/stream` match `telemetry_api.py`), tui tabs/keybindings (8 tabs, `0`-`7` jump keys, `h`/`l`/arrow nav, `f` rescan — all match `config.py`/`tui_core.py`), config tool's `supported_sources` restriction, and the `gskill_ctex26` launch profile
- [x] Verify cross-links between READMEs resolve — programmatically checked every relative markdown link across all 12 READMEs; all resolve to existing files
- [x] Spot-check documented CLI invocations against `benchlab/main.py`'s parser — diffed every `add_argument` call against the top-level README's documented flags/data-sources after pulling latest `dev-pycore`; all match, no drift