### PR TITLE
Fix PyPI install: package bootstrap.py, add pywin32 dependency

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,4 @@ jobs:
         run: pip install flake8
 
       - name: Run flake8
-        run: flake8 benchlab tests benchlab.py bootstrap.py
+        run: flake8 benchlab tests benchlab.py

--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install dependencies (pinned)
         run: |
-          pip install -r requirements.txt
+          pip install -r benchlab/requirements.txt
           pip install -r benchlab/csv_log/requirements.txt
           pip install -r benchlab/graph/requirements.txt
           pip install -r benchlab/wigidash/requirements.txt
@@ -122,7 +122,7 @@ jobs:
 
       - name: Install dependencies (latest pycore)
         run: |
-          pip install -r requirements.txt
+          pip install -r benchlab/requirements.txt
           pip install -r benchlab/csv_log/requirements.txt
           pip install -r benchlab/graph/requirements.txt
           pip install -r benchlab/wigidash/requirements.txt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
+          pip install -r benchlab/requirements.txt
           pip install -r benchlab/csv_log/requirements.txt
           pip install -r benchlab/graph/requirements.txt
           pip install -r benchlab/wigidash/requirements.txt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@
 ```bash
 git clone https://github.com/BenchLab-io/benchlab-pytools.git
 cd benchlab-pytools
-pip install -r requirements.txt
+pip install -r benchlab/requirements.txt
 pip install -r benchlab/csv_log/requirements.txt
 pip install -r benchlab/graph/requirements.txt
 pip install -r benchlab/wigidash/requirements.txt

--- a/README.md
+++ b/README.md
@@ -21,8 +21,18 @@ All tools share a common data-source layer, so the same telemetry can be read di
 
 Requires Python 3.10+.
 
+### From PyPI
+
 ```bash
-pip install -r requirements.txt
+pip install benchlab-pytools
+```
+
+This installs a `benchlab` console command on your PATH (see [Command-Line Flags](#command-line-flags) below). Install with extras for the tools you need, e.g. `pip install "benchlab-pytools[tui]"`.
+
+### From source
+
+```bash
+pip install -r benchlab/requirements.txt
 ```
 
 Each tool has its own `requirements.txt` (e.g. `benchlab/graph/requirements.txt`, `benchlab/vu/requirements.txt`). The launcher installs a tool's requirements automatically the first time it's run — you generally don't need to install them by hand.
@@ -45,11 +55,17 @@ or equivalently:
 python -m benchlab
 ```
 
+If installed from PyPI, use the `benchlab` command instead:
+
+```bash
+benchlab
+```
+
 The interactive menu (prompt_toolkit-based, with a plain-input fallback if `prompt_toolkit` isn't installed) lets you pick a data source and one or more tools, then launches them — installing any missing per-tool dependencies along the way.
 
 ### Command-Line Flags
 
-Each tool can also be launched directly with a flag:
+Each tool can also be launched directly with a flag. If installed from PyPI, replace `python -m benchlab` with `benchlab` in the examples below (e.g. `benchlab -tui`).
 
 ```bash
 python -m benchlab -tui         # Interactive terminal dashboard

--- a/benchlab.py
+++ b/benchlab.py
@@ -22,13 +22,14 @@ if not logger.handlers:
 
 
 def main():
+    sys.path.insert(0, str(BASE_DIR))
+
     # Fast fail checks first
-    from bootstrap import check_python_version, install_core_requirements
+    from benchlab.bootstrap import check_python_version, install_core_requirements
     check_python_version()
     install_core_requirements()
 
     # Delegate everything to main entry point
-    sys.path.insert(0, str(BASE_DIR))
     from benchlab.main import main
     main()
 

--- a/benchlab.py
+++ b/benchlab.py
@@ -25,7 +25,9 @@ def main():
     sys.path.insert(0, str(BASE_DIR))
 
     # Fast fail checks first
-    from benchlab.bootstrap import check_python_version, install_core_requirements
+    from benchlab.bootstrap import (
+        check_python_version, install_core_requirements,
+    )
     check_python_version()
     install_core_requirements()
 

--- a/benchlab/__init__.py
+++ b/benchlab/__init__.py
@@ -2,13 +2,4 @@
 BENCHLAB Telemetry Package
 """
 
-import os as _os
-import sys as _sys
-
-# Ensure the repo root (containing bootstrap.py) is importable. Centralized
-# here so menu.py/tools.py don't each need their own sys.path.insert hack.
-_repo_root = _os.path.dirname(_os.path.dirname(_os.path.abspath(__file__)))
-if _repo_root not in _sys.path:
-    _sys.path.insert(0, _repo_root)
-
 __version__ = "3.0.0"

--- a/benchlab/bootstrap.py
+++ b/benchlab/bootstrap.py
@@ -149,7 +149,6 @@ def install_core_requirements():
     req_file = BASE_DIR / "requirements.txt"
 
     if not req_file.exists():
-        logger.warning("No global requirements.txt found")
         return
 
     install_requirements_file(str(req_file), "CORE")

--- a/benchlab/menu.py
+++ b/benchlab/menu.py
@@ -23,7 +23,7 @@ import os
 import sys
 from typing import Dict, List, Optional, Tuple, Union
 
-from bootstrap import clear_screen
+from .bootstrap import clear_screen
 from .tools import CONSUMER_TOOLS
 from .sources import (
     check_and_setup_source,

--- a/benchlab/menu_classic.py
+++ b/benchlab/menu_classic.py
@@ -11,7 +11,7 @@ import os
 import sys
 from typing import List, Optional
 
-from bootstrap import clear_screen
+from .bootstrap import clear_screen
 from .tools import CONSUMER_TOOLS
 from .sources import (
     check_and_setup_source,

--- a/benchlab/requirements.txt
+++ b/benchlab/requirements.txt
@@ -23,3 +23,6 @@ amqtt>=0.12.0,<0.13.0
 
 # Curses-based TUI
 windows-curses>=2.4.1; platform_system=="Windows"
+
+# Named Pipe Data Source (BL_Service)
+pywin32>=306; platform_system=="Windows"

--- a/benchlab/tools.py
+++ b/benchlab/tools.py
@@ -9,7 +9,7 @@ import importlib.util
 import logging
 from pathlib import Path
 
-from bootstrap import install_requirements_file
+from .bootstrap import install_requirements_file
 
 logger = logging.getLogger("benchlab.launcher")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "textual>=0.60,<9.0",
     "benchlab-pycore>=0.5.1",
     "windows-curses>=2.4.1; platform_system=='Windows'",
+    "pywin32>=306; platform_system=='Windows'",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- Moves `bootstrap.py` and the core `requirements.txt` into `benchlab/` so they're actually included in the wheel — installing from PyPI was failing with `ModuleNotFoundError: No module named 'bootstrap'` since only `packages = ["benchlab"]` gets packaged.
- Adds `pywin32>=306; platform_system=='Windows'` to `pyproject.toml`'s core dependencies — it was only in the source-tree `requirements.txt`, so PyPI installs on Windows were missing it despite `named_pipe` source support depending on it.
- Updates path references in README/CONTRIBUTING/CI workflows to `benchlab/requirements.txt`.

Fixes #49, fixes #50

## Not included
This does **not** bump the package version. A version bump + PyPI republish is needed before these fixes actually reach users installing via `pip install benchlab-pytools` — tracking that separately, marking as draft until that's scheduled.

## Test plan
- [x] Built the wheel locally (`python -m build --wheel`) and confirmed `benchlab/bootstrap.py` and `benchlab/requirements.txt` are present in the archive
- [x] Installed the built wheel into a clean venv and ran `benchlab --help` successfully (previously failed with `ModuleNotFoundError`)
- [x] Confirmed `pywin32` appears in the wheel's `Requires-Dist` metadata
- [x] CI passes