### PR TITLE
Fix PEP 701 f-strings that break on Python 3.10/3.11

### DIFF
--- a/benchlab/config/config_client.py
+++ b/benchlab/config/config_client.py
@@ -177,8 +177,8 @@ class DirectConfigClient(ConfigClient):
 
         self.product_id = info.get('ProductId')
         logger.info(
-            f"Connected to device on {port}, Product ID: 0x{
-                self.product_id:02X}")
+            f"Connected to device on {port}, "
+            f"Product ID: 0x{self.product_id:02X}")
 
     def get_device_info(self) -> Optional[Dict[str, Any]]:
         """Get device information."""
@@ -465,8 +465,7 @@ class NamedPipeConfigClient(ConfigClient):
             win32pipe.WaitNamedPipe(path, 5000)
         except pywintypes.error as e:
             raise ConnectionError(
-                f"Pipe '{
-                    self.pipe_name}' not available: {e}") from e
+                f"Pipe '{self.pipe_name}' not available: {e}") from e
 
         self.handle = win32file.CreateFile(
             path,

--- a/benchlab/config/config_manager.py
+++ b/benchlab/config/config_manager.py
@@ -55,8 +55,7 @@ class ConfigManager:
             from benchlab_pycore.core import get_fleet_info
             devices = get_fleet_info()
             logger.info(
-                f"Discovered {
-                    len(devices)} device(s) via direct serial")
+                f"Discovered {len(devices)} device(s) via direct serial")
             return devices
         except Exception as e:
             logger.error(f"Failed to discover direct devices: {e}")
@@ -357,8 +356,8 @@ class ConfigManager:
                     device_config.selector.model_dump(), devices)
                 if not identifier:
                     logger.error(
-                        f"Device not found matching selector: {
-                            device_config.selector}")
+                        "Device not found matching selector: "
+                        f"{device_config.selector}")
                     continue
 
                 logger.info(f"Selected: {identifier}")
@@ -453,8 +452,8 @@ class ConfigManager:
                         if not client.write_fan_config(
                                 profile.profileId, fan_id, fan_dict):
                             logger.error(
-                                f"Failed to write fan config {
-                                    profile.profileId}/{fan_id}")
+                                "Failed to write fan config "
+                                f"{profile.profileId}/{fan_id}")
                             success = False
 
             # Apply RGB profiles

--- a/benchlab/core/datasource.py
+++ b/benchlab/core/datasource.py
@@ -372,8 +372,7 @@ class FastAPIDataSource(DataSource):
                 return True
             else:
                 logger.error(
-                    f"FastAPI health check returned {
-                        response.status_code}")
+                    f"FastAPI health check returned {response.status_code}")
         except Exception as e:
             logger.error(f"Failed to connect to FastAPI server: {e}")
 
@@ -1025,9 +1024,8 @@ class ServiceHttpDataSource(DataSource):
 
         if resp.status_code != 200:
             logger.error(
-                f"BenchLab service health check failed (HTTP {
-                    resp.status_code}) " f"at {
-                    self.base_url}/health")
+                f"BenchLab service health check failed "
+                f"(HTTP {resp.status_code}) at {self.base_url}/health")
             return False
 
         # Fetch initial device list
@@ -1051,8 +1049,7 @@ class ServiceHttpDataSource(DataSource):
             target=self._worker_loop, daemon=True)
         self._worker_thread.start()
         logger.info(
-            f"Connected to BenchLab service HTTP API at {
-                self.base_url}")
+            f"Connected to BenchLab service HTTP API at {self.base_url}")
         return True
 
     def disconnect(self) -> None:

--- a/benchlab/core/datasource_manager.py
+++ b/benchlab/core/datasource_manager.py
@@ -109,14 +109,14 @@ class DataSourceManager:
             self._datasource = create_datasource(self.source_type, **kwargs)
 
             if not self._datasource.connect():
-                self._last_error = f"Failed to connect to {
-                    self.source_type} datasource"
+                self._last_error = (
+                    f"Failed to connect to {self.source_type} datasource")
                 return False
 
             devices = self._datasource.list_devices()
             if not devices:
-                self._last_error = f"No devices available via {
-                    self.source_type}"
+                self._last_error = (
+                    f"No devices available via {self.source_type}")
                 return False
 
             if uid and any(d.get('uid') == uid for d in devices):
@@ -153,9 +153,8 @@ class DataSourceManager:
             self._worker_thread.start()
 
             logger.info(
-                f"Connected to {
-                    self.source_type} datasource, selected device: {
-                    self._selected_uid}")
+                f"Connected to {self.source_type} datasource, "
+                f"selected device: {self._selected_uid}")
             return True
 
         except Exception as e:

--- a/benchlab/core/infrastructure.py
+++ b/benchlab/core/infrastructure.py
@@ -80,9 +80,8 @@ class InfrastructureManager:
                 return True
 
             logger.info(
-                f"Starting FastAPI server on {
-                    self.fastapi_host}:{
-                    self.fastapi_port}")
+                f"Starting FastAPI server on "
+                f"{self.fastapi_host}:{self.fastapi_port}")
 
             try:
                 # Start FastAPI server as subprocess
@@ -107,8 +106,8 @@ class InfrastructureManager:
                     if self._wait_for_port(
                             self.fastapi_host, self.fastapi_port, timeout):
                         logger.info(
-                            f"FastAPI server started on port {
-                                self.fastapi_port}")
+                            "FastAPI server started on port "
+                            f"{self.fastapi_port}")
                         return True
                     else:
                         logger.error("FastAPI server failed to start")
@@ -171,9 +170,8 @@ class InfrastructureManager:
                 return True
 
             logger.info(
-                f"Starting MQTT publisher to {
-                    self.mqtt_broker}:{
-                    self.mqtt_port}")
+                f"Starting MQTT publisher to "
+                f"{self.mqtt_broker}:{self.mqtt_port}")
 
             try:
                 self._stop_event.clear()

--- a/benchlab/core/process_manager.py
+++ b/benchlab/core/process_manager.py
@@ -248,8 +248,7 @@ class ProcessManager:
                             os.path.abspath(__file__)),
                         "..",
                         "logs",
-                        f"svc_{
-                            mp.name}")
+                        f"svc_{mp.name}")
                     with open(f"{log_base}_stderr.log", "r",
                               encoding="utf-8") as f:
                         mp.stderr_log = f.read()

--- a/benchlab/core/statistics.py
+++ b/benchlab/core/statistics.py
@@ -202,10 +202,9 @@ class StatsFormatter:
         if min_val is None or max_val is None or avg_val is None:
             return ""
 
-        return f"{
-            min_val:.{decimals}f}-{
-            max_val:.{decimals}f} ~{
-            avg_val:.{decimals}f}{unit}"
+        return (
+            f"{min_val:.{decimals}f}-{max_val:.{decimals}f} "
+            f"~{avg_val:.{decimals}f}{unit}")
 
 
 # Convenience function for creating a stats callback

--- a/benchlab/csv_log/csv_logger_enhanced.py
+++ b/benchlab/csv_log/csv_logger_enhanced.py
@@ -141,10 +141,8 @@ class EnhancedCSVLogger:
         print("\n--- Available Devices ---")
         for i, dev in enumerate(devices, 1):
             print(
-                f"  {i}: Port: {
-                    dev.port:<12} UID: {
-                    dev.uid}  FW: {
-                    dev.firmware}")
+                f"  {i}: Port: {dev.port:<12} UID: {dev.uid}  "
+                f"FW: {dev.firmware}")
 
         selection = input(
             "\nEnter device numbers (comma-separated), 'all', "

--- a/benchlab/csv_log/message_batcher.py
+++ b/benchlab/csv_log/message_batcher.py
@@ -95,9 +95,7 @@ class MessageBatcher:
                     (self.metrics.avg_flush_time * (n - 1) + elapsed) / n
                 )
             self.logger.debug(
-                f"Flushed {
-                    len(messages_to_flush)} messages in {
-                    elapsed:.3f}s")
+                f"Flushed {len(messages_to_flush)} messages in {elapsed:.3f}s")
             return True
 
         except Exception as e:
@@ -222,8 +220,7 @@ class CSVBatchWriter:
                 elif self.format == "json":
                     self._write_json_batch(file_info, messages_to_write)
                 self.logger.debug(
-                    f"Wrote {
-                        len(messages_to_write)} rows for {uid}")
+                    f"Wrote {len(messages_to_write)} rows for {uid}")
             except Exception as e:
                 self.logger.error(f"Failed to write batch for {uid}: {e}")
                 buf.extend(messages_to_write)  # restore on failure

--- a/benchlab/csv_log/smart_retry.py
+++ b/benchlab/csv_log/smart_retry.py
@@ -104,8 +104,8 @@ class CircuitBreaker:
         if (self.config.circuit_breaker_enabled and
                 self.failure_count >= self.config.circuit_failure_threshold):
             self.logger.warning(
-                f"Circuit breaker: opening after {
-                    self.failure_count} failures")
+                "Circuit breaker: opening after "
+                f"{self.failure_count} failures")
             self.state = CircuitState.OPEN
 
 
@@ -144,9 +144,8 @@ class SmartRetryManager:
 
                 if attempt == self.config.max_retries:
                     self.logger.error(
-                        f"Max retries ({
-                            self.config.max_retries}) exceeded for {
-                            func.__name__}")
+                        f"Max retries ({self.config.max_retries}) "
+                        f"exceeded for {func.__name__}")
                     raise e
 
                 # Calculate delay
@@ -242,9 +241,8 @@ class AdaptiveRetryManager:
 
                 if attempt == self.config.max_retries:
                     self.logger.error(
-                        f"Max retries ({
-                            self.config.max_retries}) exceeded for {
-                            func.__name__}")
+                        f"Max retries ({self.config.max_retries}) "
+                        f"exceeded for {func.__name__}")
                     raise e
 
                 # Calculate adaptive delay

--- a/benchlab/graph/app.py
+++ b/benchlab/graph/app.py
@@ -263,12 +263,15 @@ class GraphApp:
                                             min_y - margin, max_y + margin)
 
                     s = self.session_stats
-                    min_text = f"Min: {
-                        s['min']:.2f}" if s["min"] is not None else "Min: --"
-                    max_text = f"Max: {
-                        s['max']:.2f}" if s["max"] is not None else "Max: --"
-                    avg_text = f"Avg: {
-                        s['avg']:.2f}" if s["avg"] is not None else "Avg: --"
+                    min_text = (
+                        f"Min: {s['min']:.2f}"
+                        if s["min"] is not None else "Min: --")
+                    max_text = (
+                        f"Max: {s['max']:.2f}"
+                        if s["max"] is not None else "Max: --")
+                    avg_text = (
+                        f"Avg: {s['avg']:.2f}"
+                        if s["avg"] is not None else "Avg: --")
                     for tag, text in (
                             ("graph_min", min_text),
                             ("graph_min_float", min_text),

--- a/benchlab/hwinfo/hwinfo_export.py
+++ b/benchlab/hwinfo/hwinfo_export.py
@@ -71,8 +71,7 @@ def write_hwinfo_sensor(device_name, sensor_type, idx, name, value, unit=None):
             # Write Value
             if isinstance(value, float):
                 winreg.SetValueEx(
-                    key, "Value", 0, winreg.REG_SZ, f"{
-                        value:.3f}")
+                    key, "Value", 0, winreg.REG_SZ, f"{value:.3f}")
             else:
                 winreg.SetValueEx(key, "Value", 0, winreg.REG_SZ, str(value))
 
@@ -156,8 +155,7 @@ def _export_grouped(device_name: str, grouped_sensors: dict):
             write_hwinfo_sensor(device_name, group, idx, key, value, unit)
 
     summary = ", ".join(
-        f"{k}: {
-            len(v)}" for k,
+        f"{k}: {len(v)}" for k,
         v in grouped_sensors.items() if v)
     logger.debug("Device %s export summary: %s", device_name, summary)
 
@@ -308,8 +306,8 @@ def export_all_devices(update_interval=1, datasource=None):
             "HWiNFO export is only supported on Windows. "
             "Please run on a Windows system.")
         raise RuntimeError(
-            f"HWiNFO export requires Windows. Current platform: {
-                sys.platform}")
+            "HWiNFO export requires Windows. "
+            f"Current platform: {sys.platform}")
 
     # Remove only old BenchLab entries, not user-created sensors
     try:

--- a/benchlab/link/link_main.py
+++ b/benchlab/link/link_main.py
@@ -217,8 +217,7 @@ class CloudMQTTClient:
                 time.sleep(0.1)
             if not self._connected:
                 logger.error(
-                    f"Timed out connecting to {host}:{
-                        self.cfg['port']}")
+                    f"Timed out connecting to {host}:{self.cfg['port']}")
                 return False
             logger.info(f"Connected to cloud broker {host}:{self.cfg['port']}")
             return True
@@ -229,9 +228,8 @@ class CloudMQTTClient:
     def reconnect(self) -> bool:
         """Attempt to reconnect using a fresh client."""
         logger.info(
-            f"Reconnecting to cloud broker {
-                self.cfg['host']}:{
-                self.cfg['port']}...")
+            f"Reconnecting to cloud broker "
+            f"{self.cfg['host']}:{self.cfg['port']}...")
         try:
             self._client.loop_stop()
         except Exception:

--- a/benchlab/sources.py
+++ b/benchlab/sources.py
@@ -145,12 +145,7 @@ import asyncio
 from amqtt.broker import Broker
 
 config = {{
-    "listeners": {{
-        "default": {{
-            "type": "tcp",
-            "bind": "0.0.0.0:{port}",
-        }},
-    }},
+    "listeners": {{"default": {{"type": "tcp", "bind": "0.0.0.0:{port}"}}}},
     "auth": {{"allow-anonymous": True}},
     "topic-check": {{"enabled": False}},
 }}

--- a/benchlab/tui/tui_core.py
+++ b/benchlab/tui/tui_core.py
@@ -210,9 +210,9 @@ class TUICore:
 
     def _render_size_warning(self, width: int, height: int):
         msg = (
-            f" Terminal too small ({width}x{height})" f" — resize to {
-                Config.MIN_TERMINAL_COLS}x{
-                Config.MIN_TERMINAL_ROWS} ")
+            f" Terminal too small ({width}x{height})"
+            f" — resize to "
+            f"{Config.MIN_TERMINAL_COLS}x{Config.MIN_TERMINAL_ROWS} ")
         try:
             self.stdscr.addstr(
                 0, 0, msg[:width],   # ← truncate, don't center
@@ -428,25 +428,17 @@ class TUICore:
         try:
             self.stdscr.addstr(6, cols['SEL'], f"{'':2}", hdr_attr)
             self.stdscr.addstr(
-                6, cols['MODEL'], f"{
-                    'Model':<{
-                        widths['MODEL']}}", hdr_attr)
+                6, cols['MODEL'],
+                f"{'Model':<{widths['MODEL']}}", hdr_attr)
             self.stdscr.addstr(
-                6, cols['PORT'], f"{
-                    'Port':<{
-                        widths['PORT']}}", hdr_attr)
+                6, cols['PORT'], f"{'Port':<{widths['PORT']}}", hdr_attr)
             self.stdscr.addstr(
-                6, cols['FW'], f"{
-                    'Firmware':<{
-                        widths['FW']}}", hdr_attr)
+                6, cols['FW'], f"{'Firmware':<{widths['FW']}}", hdr_attr)
             self.stdscr.addstr(
-                6, cols['UID'], f"{
-                    'UID':<{
-                        widths['UID']}}", hdr_attr)
+                6, cols['UID'], f"{'UID':<{widths['UID']}}", hdr_attr)
             self.stdscr.addstr(
-                6, cols['STATUS'], f"{
-                    'Status':<{
-                        widths['STATUS']}}", hdr_attr)
+                6, cols['STATUS'],
+                f"{'Status':<{widths['STATUS']}}", hdr_attr)
             self.stdscr.addstr(6, cols['ACTIVE'], "Active", hdr_attr)
         except curses.error:
             pass
@@ -490,21 +482,19 @@ class TUICore:
             try:
                 self.stdscr.addstr(row, cols['SEL'], cursor, row_color)
                 self.stdscr.addstr(
-                    row, cols['MODEL'], f"{
-                        model_str:<{
-                            widths['MODEL']}}", row_color)
+                    row, cols['MODEL'],
+                    f"{model_str:<{widths['MODEL']}}", row_color)
                 self.stdscr.addstr(
-                    row, cols['PORT'], f"{
-                        port:<{
-                            widths['PORT']}}", row_color)
+                    row, cols['PORT'],
+                    f"{port:<{widths['PORT']}}", row_color)
 
                 if is_busy:
                     self.stdscr.addstr(
-                        row, cols['FW'], f"{'N/A':<{widths['FW']}}", row_color)
+                        row, cols['FW'],
+                        f"{'N/A':<{widths['FW']}}", row_color)
                     self.stdscr.addstr(
-                        row, cols['UID'], f"{
-                            dev_uid:<{
-                                widths['UID']}}", curses.color_pair(
+                        row, cols['UID'], f"{dev_uid:<{widths['UID']}}",
+                        curses.color_pair(
                             Config.COLOR_PAIRS['caution']) | curses.A_BOLD)
                 else:
                     try:
@@ -513,18 +503,15 @@ class TUICore:
                     except (TypeError, ValueError):
                         fw_str = "0x????????"
                     self.stdscr.addstr(
-                        row, cols['FW'], f"{
-                            fw_str:<{
-                                widths['FW']}}", row_color)
+                        row, cols['FW'],
+                        f"{fw_str:<{widths['FW']}}", row_color)
                     self.stdscr.addstr(
-                        row, cols['UID'], f"{
-                            dev_uid:<{
-                                widths['UID']}}", row_color)
+                        row, cols['UID'],
+                        f"{dev_uid:<{widths['UID']}}", row_color)
 
                 self.stdscr.addstr(
-                    row, cols['STATUS'], f"{
-                        status:<{
-                            widths['STATUS']}}", status_color)
+                    row, cols['STATUS'],
+                    f"{status:<{widths['STATUS']}}", status_color)
 
                 if is_active:
                     self.stdscr.addstr(
@@ -616,8 +603,7 @@ class TUICore:
 
             self._draw_section(16, 2, "TUI")
             self.stdscr.addstr(
-                17, 4, f"{
-                    'Refresh Interval':<22} {refresh_interval} s")
+                17, 4, f"{'Refresh Interval':<22} {refresh_interval} s")
 
         except curses.error:
             pass
@@ -1145,8 +1131,7 @@ class TUICore:
                 self.stdscr.addstr(
                     row,
                     cols['NAME'] + 2,
-                    f"Fan{
-                        i:<5}",
+                    f"Fan{i:<5}",
                     fan_color)
                 self.stdscr.addstr(
                     row, cols['DUTY'] + 2, f"{duty:>5}%", fan_color)
@@ -1282,9 +1267,7 @@ class TUICore:
 
         try:
             self.stdscr.addstr(
-                y, x, f"{
-                    label:<14} {val_str} {
-                    unit:<3} ", color)
+                y, x, f"{label:<14} {val_str} {unit:<3} ", color)
             self.stdscr.addstr(bar, color)
 
             if stat and stat[0] is not None:

--- a/benchlab/tui/tui_main.py
+++ b/benchlab/tui/tui_main.py
@@ -118,8 +118,8 @@ class TUIApplication:
 
         if self.source_type == 'fastapi':
             if hasattr(args, 'api_port'):
-                datasource_kwargs['base_url'] = f"http://127.0.0.1:{
-                    args.api_port}"
+                datasource_kwargs['base_url'] = (
+                    f"http://127.0.0.1:{args.api_port}")
             else:
                 datasource_kwargs['base_url'] = "http://127.0.0.1:8000"
             datasource_kwargs['timeout'] = 5.0
@@ -234,26 +234,22 @@ class TUIApplication:
             if self.datasource_manager.connect():
                 uid = self.datasource_manager.get_selected_uid()
                 self.tui_core.set_status(
-                    f"Connected via {
-                        self.source_type.upper()}")
+                    f"Connected via {self.source_type.upper()}")
                 logger.info(
-                    f"Connected to {
-                        self.source_type} datasource, selected: {uid}")
+                    f"Connected to {self.source_type} datasource, "
+                    f"selected: {uid}")
             else:
                 snapshot = self.datasource_manager.snapshot()
                 error_msg = snapshot.get(
-                    'last_error', f"Failed to connect to {
-                        self.source_type}")
+                    'last_error', f"Failed to connect to {self.source_type}")
                 self.tui_core.set_status(
                     f"Connection failed: {error_msg}", 5.0)
                 logger.error(
-                    f"Failed to connect to {
-                        self.source_type}: {error_msg}")
+                    f"Failed to connect to {self.source_type}: {error_msg}")
         except Exception as e:
             self.tui_core.set_status(f"Connection error: {str(e)}", 5.0)
             logger.error(
-                f"Exception during {
-                    self.source_type} connection: {e}")
+                f"Exception during {self.source_type} connection: {e}")
 
     def _connect_to_device(self, device: Dict[str, Any]):
         port = device.get('port')
@@ -280,8 +276,7 @@ class TUIApplication:
                 if self.datasource_manager.select_device(uid):
                     self.tui_core.set_status(f"Selected device {uid}")
                     logger.info(
-                        f"Selected device {uid} via {
-                            self.source_type}")
+                        f"Selected device {uid} via {self.source_type}")
                 else:
                     self.tui_core.set_status("Failed to select device", 3.0)
                     logger.warning(f"Failed to select device {uid}")

--- a/benchlab/vu/vu_server_manager.py
+++ b/benchlab/vu/vu_server_manager.py
@@ -147,8 +147,7 @@ def start_vu_server() -> subprocess.Popen | None:
         time.sleep(1)
         if check_vu_server(new_cfg["vu_server_url"], new_cfg["api_key"]):
             logger.info(
-                f"VU server is now running at {
-                    new_cfg['vu_server_url']}")
+                f"VU server is now running at {new_cfg['vu_server_url']}")
             break
     else:
         logger.error("Failed to verify VU server after startup.")
@@ -159,8 +158,7 @@ def start_vu_server() -> subprocess.Popen | None:
     try:
         VU_SERVER_CONFIG.write_text(json.dumps(new_cfg, indent=2))
         logger.info(
-            f"Updated {VU_SERVER_CONFIG} with {
-                new_cfg['vu_server_url']}")
+            f"Updated {VU_SERVER_CONFIG} with {new_cfg['vu_server_url']}")
     except Exception as e:
         logger.warning(f"Failed to write {VU_SERVER_CONFIG}: {e}")
 

--- a/benchlab/vu/vu_tui.py
+++ b/benchlab/vu/vu_tui.py
@@ -133,15 +133,11 @@ class VUTUI:
                 if hasattr(b, "close") and callable(b.close):
                     b.close()
                     logger.info(
-                        f"Closed serial port for benchlab {
-                            b.get(
-                                'port', '?')}")
+                        "Closed serial port for benchlab "
+                        f"{b.get('port', '?')}")
             except Exception as e:
                 logger.warning(
-                    f"Failed to close port {
-                        b.get(
-                            'port',
-                            '?')}: {e}")
+                    f"Failed to close port {b.get('port', '?')}: {e}")
 
         logger.info("Cleanup complete.")
 
@@ -213,10 +209,9 @@ class VUTUI:
                 })
 
     def update_dial_name_on_server(self, dial_uid, new_name):
-        url = f"{
-            self.server_cfg.get(
-                'vu_server_url',
-                'http://localhost:5340')}/api/v0/dial/{dial_uid}/name"
+        server_url = self.server_cfg.get(
+            'vu_server_url', 'http://localhost:5340')
+        url = f"{server_url}/api/v0/dial/{dial_uid}/name"
         params = {
             "key": self.server_cfg.get("api_key", ""),
             "name": new_name
@@ -227,9 +222,8 @@ class VUTUI:
                 return True
             else:
                 logger.warning(
-                    f"Failed to update dial {dial_uid} name on server: {
-                        resp.status_code} {
-                        resp.text}")
+                    f"Failed to update dial {dial_uid} name on server: "
+                    f"{resp.status_code} {resp.text}")
         except Exception as e:
             logger.warning(
                 f"Exception updating dial {dial_uid} name on server: {e}")
@@ -555,23 +549,22 @@ class VUTUI:
         col_min_width = 5
         col_max_width = 5
 
-        self.stdscr.addstr(
-            y, 2, f"{
-                'Dial UID':<{col_uid_width}} {
-                'Dial Name':<{col_name_width}} " f"{
-                'Benchlab':<{col_port_width}} {
-                    'Min':<{col_min_width}} " f"{
-                        'Max':<{col_max_width}} Sensor", curses.A_UNDERLINE)
+        header_line = (
+            f"{'Dial UID':<{col_uid_width}} "
+            f"{'Dial Name':<{col_name_width}} "
+            f"{'Benchlab':<{col_port_width}} "
+            f"{'Min':<{col_min_width}} "
+            f"{'Max':<{col_max_width}} Sensor")
+        self.stdscr.addstr(y, 2, header_line, curses.A_UNDERLINE)
         y += 1
 
         for idx, dial in enumerate(self.all_dials):
-            line = f"{
-                dial['uid']:<{col_uid_width}} {
-                dial['name']:<{col_name_width}} " f"{
-                dial['benchlab_port']:<{col_port_width}} {
-                dial['min']:<{col_min_width}} " f"{
-                    dial['max']:<{col_max_width}} {
-                        dial['sensor']}"
+            line = (
+                f"{dial['uid']:<{col_uid_width}} "
+                f"{dial['name']:<{col_name_width}} "
+                f"{dial['benchlab_port']:<{col_port_width}} "
+                f"{dial['min']:<{col_min_width}} "
+                f"{dial['max']:<{col_max_width}} {dial['sensor']}")
             self.stdscr.addstr(
                 y + idx,
                 2,
@@ -717,8 +710,8 @@ class VUTUI:
                 self.stdscr.addstr(h - num_rows - 3 + row,
                                    x, s_str[:col_width - 1])
 
-            prompt = f"Select sensor number for {
-                dial['name']} or 'q' to skip: "
+            prompt = (
+                f"Select sensor number for {dial['name']} or 'q' to skip: ")
             self.stdscr.move(h - 4, 0)
             self.stdscr.clrtoeol()
             self.stdscr.addstr(h - 3, 0, prompt[:w - 1])
@@ -900,8 +893,8 @@ def launch_vu_config(args=None):
         datasource = DataSourceManager(source_type=args.source, **ds_kwargs)
         if not datasource.connect():
             logger.warning(
-                f"Could not connect to {
-                    args.source} datasource — sensor list may be empty")
+                f"Could not connect to {args.source} datasource — "
+                "sensor list may be empty")
     except Exception:
         # run_vu_tui's own cleanup (which terminates server_proc) never runs
         # if we fail before reaching curses.wrapper below, so terminate it

--- a/benchlab/vu/vu_updater.py
+++ b/benchlab/vu/vu_updater.py
@@ -167,9 +167,9 @@ class VUClient:
 
     def get_dial_image_crc(self, dial_uid: str) -> str:
         try:
-            headers = {
-                "Authorization": f"Bearer {
-                    self.api_key}"} if self.api_key else {}
+            headers = (
+                {"Authorization": f"Bearer {self.api_key}"}
+                if self.api_key else {})
             r = requests.get(
                 f"{self.server_url}/api/v0/dial/{dial_uid}/image/crc",
                 headers=headers, timeout=10)

--- a/benchlab/wigidash/benchlab_fleet.py
+++ b/benchlab/wigidash/benchlab_fleet.py
@@ -104,8 +104,8 @@ class BenchlabFleetSelect:
             if 50 <= x <= 966 and y0 <= y <= y1:
                 self.selected_port = dev["port"]
                 logger.info(
-                    f"Fleet selection done on {
-                        self.selected_port}, opening Overview.")
+                    f"Fleet selection done on {self.selected_port}, "
+                    "opening Overview.")
                 if self.manager and self.wigi:
                     self.manager.start_telemetry(self.selected_port, self.wigi)
 

--- a/benchlab/wigidash/benchlab_graph.py
+++ b/benchlab/wigidash/benchlab_graph.py
@@ -67,8 +67,7 @@ class BenchlabGraph:
     def start(self):
         self.running = True
         logger.info(
-            f"Graph page started with metrics: {
-                self.selected_metrics}")
+            f"Graph page started with metrics: {self.selected_metrics}")
 
     def return_to_overview(self):
         logger.info("Returning to Overview page")
@@ -163,8 +162,8 @@ class BenchlabGraph:
                    if f"{r}_{key_suffix}" in self.wigi.sensor_data]
         self.plot_metrics = metrics
         logger.info(
-            f"Graph metrics updated for section '{key_suffix}': {
-                self.plot_metrics}")
+            f"Graph metrics updated for section '{key_suffix}': "
+            f"{self.plot_metrics}")
 
     # -------------------------------
     # Rendering

--- a/benchlab/wigidash/wigidash_device.py
+++ b/benchlab/wigidash/wigidash_device.py
@@ -189,8 +189,8 @@ class WigidashDevice:
         wValue = (page << 8) | widget_id
         widget_bytes = bytes(widget_config)
         logger.debug(
-            f"Adding widget page={page}, id={widget_id}, size={
-                len(widget_bytes)} bytes")
+            f"Adding widget page={page}, id={widget_id}, "
+            f"size={len(widget_bytes)} bytes")
         self.usb.ctrl_transfer_out(
             cmd=self.CMD_SCREENCFG_WIDGET_ADD,
             wValue=wValue,

--- a/benchlab/wigidash/wigidash_manager.py
+++ b/benchlab/wigidash/wigidash_manager.py
@@ -76,9 +76,8 @@ class WigidashManager:
         if log_info:
             count = len(all_devices)
             if count:
-                logger.info(
-                    f"{count} available Benchlab device{
-                        's' if count > 1 else ''}:")
+                plural = 's' if count > 1 else ''
+                logger.info(f"{count} available Benchlab device{plural}:")
                 for dev in all_devices:
                     logger.info(f"  {dev['port']}: UID {dev['uid']}")
             else:
@@ -309,9 +308,7 @@ def main(args=None):
         ds_kwargs["broker"] = args.mqtt_broker
         ds_kwargs["port"] = args.mqtt_port
         logger.info(
-            f"Using MQTT datasource: {
-                args.mqtt_broker}:{
-                args.mqtt_port}")
+            f"Using MQTT datasource: {args.mqtt_broker}:{args.mqtt_port}")
     else:
         logger.info("Using direct datasource")
 

--- a/benchlab/wigidash/wigidash_session.py
+++ b/benchlab/wigidash/wigidash_session.py
@@ -131,8 +131,7 @@ class BenchlabWigiSession:
     def connect_wigidash(self):
         """Initialize the Wigidash device and UI."""
         logger.info(
-            f"Initializing Wigidash device {
-                self.usb_device.serial} ...")
+            f"Initializing Wigidash device {self.usb_device.serial} ...")
         try:
             self.usb_device.connect()
             self.wigidash = WigidashDevice(self.usb_device)
@@ -148,13 +147,12 @@ class BenchlabWigiSession:
             self.keepalive_manager.start()
 
             logger.info(
-                f"Wigidash device {
-                    self.usb_device.serial} initialized successfully.")
+                f"Wigidash device {self.usb_device.serial} "
+                "initialized successfully.")
             return True
         except Exception as e:
             logger.error(
-                f"Failed to initialize Wigidash {
-                    self.usb_device.serial}: {e}")
+                f"Failed to initialize Wigidash {self.usb_device.serial}: {e}")
             try:
                 self.usb_device.disconnect()
             except Exception:
@@ -201,9 +199,8 @@ class BenchlabWigiSession:
     def run(self):
         """Run UI loop for Wigidash pages."""
         logger.info(
-            f"Session {
-                self.usb_device.serial} started with manager={
-                self.manager}")
+            f"Session {self.usb_device.serial} started with "
+            f"manager={self.manager}")
         if not self.connect_wigidash():
             return
 
@@ -229,8 +226,7 @@ class BenchlabWigiSession:
                     )
                     self.fleet_page.start()
                     logger.info(
-                        f"Fleet page started for {
-                            self.usb_device.serial}.")
+                        f"Fleet page started for {self.usb_device.serial}.")
 
                 self.fleet_page.check_touch(touch)
                 self.fleet_page.render_and_display()
@@ -258,8 +254,8 @@ class BenchlabWigiSession:
                     self.next_page = "overview"
                     self.fleet_page = None
                     logger.info(
-                        f"Fleet selection done on {
-                            self.usb_device.serial}, opening Overview.")
+                        f"Fleet selection done on "
+                        f"{self.usb_device.serial}, opening Overview.")
 
             # --- Overview Page ---
             elif self.next_page == "overview":
@@ -276,8 +272,8 @@ class BenchlabWigiSession:
                             self.graph_metrics = requested_metrics
                             self.next_page = "graph"
                             logger.info(
-                                f"Overview requested graph metrics: {
-                                    self.graph_metrics}")
+                                "Overview requested graph metrics: "
+                                f"{self.graph_metrics}")
                         else:
                             self.next_page = "fleet"
 
@@ -294,9 +290,8 @@ class BenchlabWigiSession:
                     )
                     self.graph_page.start()
                     logger.info(
-                        f"Graph page started for {
-                            self.usb_device.serial} with metrics {
-                            self.graph_metrics}.")
+                        f"Graph page started for {self.usb_device.serial} "
+                        f"with metrics {self.graph_metrics}.")
 
                 self.graph_page.check_touch(touch)
                 self.graph_page.render_and_display()
@@ -305,8 +300,8 @@ class BenchlabWigiSession:
                     self.graph_page = None
                     self.next_page = "overview"
                     logger.info(
-                        f"Graph page exited for {
-                            self.usb_device.serial}, returning to Overview.")
+                        f"Graph page exited for {self.usb_device.serial}, "
+                        "returning to Overview.")
 
             time.sleep(0.05)
 
@@ -341,8 +336,7 @@ class BenchlabWigiSession:
                 barrier.wait()
             except threading.BrokenBarrierError:
                 logger.warning(
-                    f"Shutdown barrier broken for {
-                        self.usb_device.serial}")
+                    f"Shutdown barrier broken for {self.usb_device.serial}")
 
         # Show splash
         if self.wigidash:

--- a/benchlab/wigidash/wigidash_usb.py
+++ b/benchlab/wigidash/wigidash_usb.py
@@ -147,9 +147,9 @@ def scan_wigidash(vendor_id=0x28DA, product_id=0xEF01):
             usb_dev = USBDevice(vendor_id, product_id, serial=serial)
             usb_dev.dev = dev
             logger.info(
-                f"Wigidash device found and configured: VID:0x{
-                    vendor_id:04X}, PID:0x{
-                    product_id:04X}, Serial: {serial}")
+                "Wigidash device found and configured: "
+                f"VID:0x{vendor_id:04X}, PID:0x{product_id:04X}, "
+                f"Serial: {serial}")
             devices.append(usb_dev)
         except usb.core.USBError as e:
             if is_linux and _is_permission_error(e):
@@ -175,8 +175,7 @@ class USBDevice:
         try:
             self.dev.set_configuration()
             logger.info(
-                f"USB device configured successfully, serial: {
-                    self.serial}")
+                f"USB device configured successfully, serial: {self.serial}")
         except usb.core.USBError as e:
             if is_linux and _is_permission_error(e):
                 logger.warning(
@@ -205,8 +204,7 @@ class USBDevice:
             data = self.dev.ctrl_transfer(
                 0x80 | 0x21, cmd, wValue, wIndex, length, timeout=timeout)
             logger.debug(
-                f"IN transfer cmd=0x{
-                    cmd:02X}, length={length} → {data}")
+                f"IN transfer cmd=0x{cmd:02X}, length={length} → {data}")
             return data
         except usb.core.USBError as e:
             logger.error(f"IN transfer failed: {e}")
@@ -238,9 +236,7 @@ class USBDevice:
         try:
             written = self.dev.write(endpoint, data, timeout=timeout)
             logger.debug(
-                f"Bulk write to ep=0x{
-                    endpoint:02X}, len={
-                    len(data)} bytes")
+                f"Bulk write to ep=0x{endpoint:02X}, len={len(data)} bytes")
             return written
         except usb.core.USBError as e:
             logger.error(f"Bulk write failed: {e}")

--- a/benchlab/wigidash/wigidash_widget.py
+++ b/benchlab/wigidash/wigidash_widget.py
@@ -47,8 +47,7 @@ class WidgetConfig(Structure):
     @InvalidateFlag.setter
     def InvalidateFlag(self, value):
         logger.debug(
-            f"InvalidateFlag changed: {
-                self._InvalidateFlag} → {value}")
+            f"InvalidateFlag changed: {self._InvalidateFlag} → {value}")
         self._InvalidateFlag = value
 
     @property
@@ -58,8 +57,7 @@ class WidgetConfig(Structure):
     @UpdateFromCache.setter
     def UpdateFromCache(self, value):
         logger.debug(
-            f"UpdateFromCache changed: {
-                self._UpdateFromCache} → {value}")
+            f"UpdateFromCache changed: {self._UpdateFromCache} → {value}")
         self._UpdateFromCache = value
 
     @classmethod

--- a/tests/test_tool_sources.py
+++ b/tests/test_tool_sources.py
@@ -223,12 +223,8 @@ def device():
             "No BenchLab device found – skipping tool integration tests")
     dev = devices[0]
     _ok(
-        f"Found device: uid={
-            dev['uid']}  port={
-            dev['port']}  fw={
-                dev.get(
-                    'fw',
-                    '?')}")
+        f"Found device: uid={dev['uid']}  port={dev['port']}  "
+        f"fw={dev.get('fw', '?')}")
     return dev
 
 


### PR DESCRIPTION
## Summary
- Several f-strings across `benchlab/` had their `{...}` expression split across a line break. That grammar (arbitrary multi-line expressions inside f-strings) is [PEP 701](https://peps.python.org/pep-0701/), which only landed in Python 3.12.
- `pyproject.toml` declares `requires-python = ">=3.10"`, so this raised `SyntaxError` immediately on 3.10/3.11 — e.g. `benchlab -tui --source direct` failing with `SyntaxError: unterminated string literal` in `benchlab/core/datasource.py`.
- This was invisible in CI because every workflow (`lint.yml`, `pycore-compat.yml`, `release.yml`) pins `python-version: "3.13"`.

Fixes #53

## Changes
Collapsed ~93 multi-line f-string expressions back onto single lines across 27 files in `benchlab/` and `tests/`, rewrapping/splitting into adjacent string literals where needed to stay under flake8's 79-char line limit. No behavior changes — purely mechanical.

## Follow-up not included here
CI runs 3.13 everywhere, so the declared `>=3.10` floor isn't actually exercised. Worth adding a 3.10 (or 3.11) job to at least one workflow to catch this class of bug going forward — tracked as a note in #53 but out of scope for this PR.

## Test plan
- [x] `flake8 benchlab tests benchlab.py` — clean
- [x] `python -m py_compile` on every changed file — all compile under 3.14
- [x] Scanned the whole repo for any remaining multi-line f-string braces — none found
- [x] Full `pytest` suite — 200 passed, 42 skipped, no regressions
- [ ] CI passes