### PR TITLE
Fix TUI 12VHPWR truncation and missing device info on mqtt/service_http/named_pipe

### DIFF
--- a/benchlab/core/datasource.py
+++ b/benchlab/core/datasource.py
@@ -740,22 +740,25 @@ def _normalise_cs_telemetry(sensors_raw: list) -> Dict[str, Any]:
 def _normalise_cs_device_info(d: Dict[str, Any]) -> Dict[str, Any]:
     """Normalise a C# service device dict into the shape the TUI expects.
 
-    The C# service's /devices and discovery-pipe responses use camelCase
-    keys (productId, vendorId, firmwareVersion). DirectDataSource and
-    FastAPIDataSource populate PascalCase keys (ProductId, VendorId,
-    FwVersion) plus a computed 'variant' — this adds those same keys
-    without discarding whatever the C# service already provided.
+    The C# service's /devices, /device/{uid}/info, and discovery-pipe
+    responses use camelCase keys (productId, vendorId, firmwareVersion —
+    confirmed against BenchlabSensorWorker.cs/HttpApiServer.cs in the
+    BENCHLAB_Service repo). Note the HTTP API's /devices and
+    /device/{uid}/info endpoints only send productId — no vendorId or
+    firmwareVersion — so those default to 0 there; only the named-pipe
+    discovery/GetServiceInfo responses include all three.
+    DirectDataSource/FastAPIDataSource populate PascalCase keys
+    (ProductId, VendorId, FwVersion) plus a computed 'variant' — this
+    adds those same keys without discarding what the C# service sent.
     """
     result = dict(d)
     product_id = d.get("ProductId", d.get("productId", 0))
     vendor_id = d.get("VendorId", d.get("vendorId", 0))
-    fw_version = d.get(
-        "FwVersion", d.get("firmwareVersion", d.get("fwVersion", 0)))
+    fw_version = d.get("FwVersion", d.get("firmwareVersion", 0))
     result["ProductId"] = product_id
     result["VendorId"] = vendor_id
     result["FwVersion"] = fw_version
-    result.setdefault(
-        "firmware", d.get("firmware", fw_version))
+    result.setdefault("firmware", d.get("firmware", fw_version))
     # 0x11 = BENCHLAB_BL2_PRODUCT_ID (see DirectDataSource/tui_core.py).
     result.setdefault(
         "variant", "BL2" if product_id == 0x11 else "ORIGINAL")
@@ -825,9 +828,11 @@ class NamedPipeDataSource(DataSource):
             self._pipe_names.clear()
             for d in devices:
                 uid = d.get("guid") or d.get("deviceName", "unknown")
+                # Field names confirmed against BenchlabSensorWorker.cs's
+                # ListDevices response in the BENCHLAB_Service repo.
                 product_id = d.get("productId", 0)
                 vendor_id = d.get("vendorId", 0)
-                fw_version = d.get("firmwareVersion", d.get("fwVersion", 0))
+                fw_version = d.get("firmwareVersion", 0)
                 # 0x11 = BENCHLAB_BL2_PRODUCT_ID (see
                 # DirectDataSource/tui_core.py); hardcoded rather than
                 # importing benchlab_pycore, which named_pipe consumers

--- a/benchlab/core/datasource.py
+++ b/benchlab/core/datasource.py
@@ -595,7 +595,15 @@ class MQTTDataSource(DataSource):
 
         with self._lock:
             return [
-                {'uid': uid, 'port': info.get('com_port', 'unknown')}
+                {
+                    'uid': uid,
+                    'port': info.get('com_port', 'unknown'),
+                    'firmware': info.get('firmware', '?'),
+                    'variant': info.get('variant'),
+                    'VendorId': info.get('VendorId', 0),
+                    'ProductId': info.get('ProductId', 0),
+                    'FwVersion': info.get('FwVersion', 0),
+                }
                 for uid, info in self._device_info.items()
             ]
 
@@ -729,6 +737,31 @@ def _normalise_cs_telemetry(sensors_raw: list) -> Dict[str, Any]:
     return result
 
 
+def _normalise_cs_device_info(d: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise a C# service device dict into the shape the TUI expects.
+
+    The C# service's /devices and discovery-pipe responses use camelCase
+    keys (productId, vendorId, firmwareVersion). DirectDataSource and
+    FastAPIDataSource populate PascalCase keys (ProductId, VendorId,
+    FwVersion) plus a computed 'variant' — this adds those same keys
+    without discarding whatever the C# service already provided.
+    """
+    result = dict(d)
+    product_id = d.get("ProductId", d.get("productId", 0))
+    vendor_id = d.get("VendorId", d.get("vendorId", 0))
+    fw_version = d.get(
+        "FwVersion", d.get("firmwareVersion", d.get("fwVersion", 0)))
+    result["ProductId"] = product_id
+    result["VendorId"] = vendor_id
+    result["FwVersion"] = fw_version
+    result.setdefault(
+        "firmware", d.get("firmware", fw_version))
+    # 0x11 = BENCHLAB_BL2_PRODUCT_ID (see DirectDataSource/tui_core.py).
+    result.setdefault(
+        "variant", "BL2" if product_id == 0x11 else "ORIGINAL")
+    return result
+
+
 class NamedPipeDataSource(DataSource):
     """Data source that connects to the C# BenchLab Windows service via
     named pipes.
@@ -792,14 +825,29 @@ class NamedPipeDataSource(DataSource):
             self._pipe_names.clear()
             for d in devices:
                 uid = d.get("guid") or d.get("deviceName", "unknown")
+                product_id = d.get("productId", 0)
+                vendor_id = d.get("vendorId", 0)
+                fw_version = d.get("firmwareVersion", d.get("fwVersion", 0))
+                # 0x11 = BENCHLAB_BL2_PRODUCT_ID (see
+                # DirectDataSource/tui_core.py); hardcoded rather than
+                # importing benchlab_pycore, which named_pipe consumers
+                # of the C# service don't necessarily have installed.
+                variant = "BL2" if product_id == 0x11 else "ORIGINAL"
                 self._devices[uid] = {
                     "uid": uid,
                     "port": d.get("port", "unknown"),
                     "name": d.get("deviceName", "unknown"),
-                    "productId": d.get("productId", 0),
+                    "productId": product_id,
                     "status": d.get("status", "unknown"),
                     "sensorCount": d.get("sensorCount", 0),
                     "pipeName": d.get("pipeName", ""),
+                    # PascalCase aliases matching DirectDataSource's shape,
+                    # so consumers (e.g. the TUI) can detect BL1/BL2.
+                    "firmware": fw_version,
+                    "variant": variant,
+                    "VendorId": vendor_id,
+                    "ProductId": product_id,
+                    "FwVersion": fw_version,
                 }
                 self._pipe_names[uid] = d.get("pipeName", "")
 
@@ -1041,7 +1089,7 @@ class ServiceHttpDataSource(DataSource):
                 for d in devices:
                     uid = d.get("uid", "")
                     if uid:
-                        self._devices[uid] = d
+                        self._devices[uid] = _normalise_cs_device_info(d)
 
         self._connected = True
         self._stop_event.clear()
@@ -1146,7 +1194,8 @@ class ServiceHttpDataSource(DataSource):
                         for d in devices:
                             uid = d.get("uid", "")
                             if uid:
-                                self._devices[uid] = d
+                                self._devices[uid] = (
+                                    _normalise_cs_device_info(d))
 
                 # Poll telemetry for each device
                 with self._lock:

--- a/benchlab/mqtt/mqtt_publisher.py
+++ b/benchlab/mqtt/mqtt_publisher.py
@@ -17,6 +17,11 @@ from benchlab_pycore.core import (
     read_device,
     BENCHLAB_ORIGINAL_PRODUCT_ID,
 )
+try:
+    from benchlab_pycore.core import BENCHLAB_BL2_PRODUCT_ID
+except ImportError:
+    from benchlab_pycore.core import (
+        BENCHLAB_CFE_PRODUCT_ID as BENCHLAB_BL2_PRODUCT_ID)
 from benchlab_pycore.core.serial_io import get_fleet_info
 
 # Import DeviceRegistry so the MQTT publisher publishes device lifecycle events
@@ -340,12 +345,36 @@ def device_thread(device, cfg, publish_interval=1):
                     time.sleep(1)
                     continue
 
+                # Read device info (ProductId/VendorId/FwVersion) so the
+                # info payload lets consumers (e.g. the TUI) detect the
+                # BL1/BL2 variant, matching DirectDataSource's shape.
+                vendor_id = 0
+                product_id = BENCHLAB_ORIGINAL_PRODUCT_ID
+                fw_version = device.get("firmware")
+                try:
+                    dev_info = read_device(ser)
+                    if dev_info:
+                        vendor_id = dev_info.get('VendorId', 0)
+                        product_id = dev_info.get(
+                            'ProductId', BENCHLAB_ORIGINAL_PRODUCT_ID)
+                        fw_version = dev_info.get('FwVersion', fw_version)
+                except Exception:
+                    pass
+                variant = (
+                    "BL2" if product_id == BENCHLAB_BL2_PRODUCT_ID
+                    else "ORIGINAL")
+
                 # Send initial info payload (retain=True so late subscribers
                 # like the TUI can discover this device)
                 info_payload = {
                     "uid": uid,
                     "com_port": port,
-                    "firmware": device.get("firmware")}
+                    "firmware": device.get("firmware"),
+                    "VendorId": vendor_id,
+                    "ProductId": product_id,
+                    "FwVersion": fw_version,
+                    "variant": variant,
+                }
                 topic_info = f"{cfg['topic_prefix']}/{uid}/info"
                 mqtt_publish(
                     client,

--- a/benchlab/tui/config.py
+++ b/benchlab/tui/config.py
@@ -14,7 +14,10 @@ from typing import Tuple
 # ═══════════════════════════════════════════════════════════════════════════════
 
 # Minimum terminal size requirements
-MIN_TERMINAL_ROWS = 35
+# The 12VHPWR tab's stacked Power/Current/Voltage sections (12 channels
+# each) need rows through ~45 for the last Voltage bar, plus 2 rows for
+# the status bar at the bottom (drawn at height-2/height-1).
+MIN_TERMINAL_ROWS = 48
 MIN_TERMINAL_COLS = 100
 
 # Tab configuration


### PR DESCRIPTION
## Summary
Two independent issues reported after testing 3.0.2:

**1. 12VHPWR tab cut off (#56)** — `MIN_TERMINAL_ROWS` was 35, but the stacked Power/Current/Voltage layout (12 channels each) plus the status bar needs ~48 rows. Draw calls silently swallow `curses.error` on overflow, so the Voltage section just vanished partway through with no error and no way to scroll (no scroll mechanism exists anywhere in the TUI). Raised the minimum to 48.

**2. Wrong/missing Model on Fleet page for mqtt/service_http/named_pipe (#57)** — only `direct` and `fastapi` sources populated `ProductId`/`VendorId`/`FwVersion`/`variant`. Fixed each:
- **mqtt**: publisher now reads device info via `read_device()` and includes it in the retained `.../info` payload; consumer's `list_devices()` now surfaces it.
- **named_pipe**: maps the C# service's camelCase `productId` (and best-guess `vendorId`/`firmwareVersion`) to the PascalCase keys the TUI expects, computing `variant`.
- **service_http**: new `_normalise_cs_device_info()` helper (mirrors the existing `_normalise_cs_telemetry()` for sensor data), applied on connect and in the background refresh loop.

## Caveat
I don't have the C# BenchLab service's source in this repo, so the exact field-name casing it returns for vendor/firmware on named_pipe and service_http is a best guess based on the one confirmed field (`productId`). Defensive `.get()` fallbacks mean worst case is `variant` staying `ORIGINAL`/unset rather than crashing — but worth confirming against a live service if the Model column is still wrong for these two sources after this lands.

## Test plan
- [x] `flake8` clean on all changed files
- [x] All changed files compile
- [x] Full `pytest` suite — 200 passed, 42 skipped, no regressions
- [x] Manual verification against real hardware/service for mqtt, service_http, named_pipe (I don't have hardware access — please verify)
- [x] CI passes