### PR TITLE
Fix 12VHPWR per-pin sense lines reading 0.0 over service_http/named_pipe

### DIFF
--- a/benchlab/core/datasource.py
+++ b/benchlab/core/datasource.py
@@ -698,6 +698,16 @@ def _normalise_cs_telemetry(sensors_raw: list) -> Dict[str, Any]:
         "HPWR2_P": "HPWR2_Power", "HPWR2_V": "HPWR2_Voltage",
         "HPWR2_I": "HPWR2_Current",
 
+        # BL2 12VHPWR per-pin sense lines (HPWR{1,2}_W{1..6}), shown on
+        # the TUI's 12VHPWR tab as HPWR{n}_W{m}_{Power,Current,Voltage}
+        **{
+            f"HPWR{n}_W{m}_{suffix}": f"HPWR{n}_W{m}_{tui_suffix}"
+            for n in (1, 2)
+            for m in range(1, 7)
+            for suffix, tui_suffix in (
+                ("P", "Power"), ("I", "Current"), ("V", "Voltage"))
+        },
+
         # Board voltages
         "VDD": "Vdd",
         "VREF": "Vref",


### PR DESCRIPTION
## Summary
The 12VHPWR tab showed 0.0 for all bars over `service_http`/`named_pipe` sources, even though other apps using the same `service_http` API display these values correctly — confirming the raw telemetry is there, just mis-mapped on the Python consumer side.

## Root cause
`_normalise_cs_telemetry()` (`benchlab/core/datasource.py`) already mapped the HPWR1/HPWR2 *rail summary* keys (`HPWR1_P` → `HPWR1_Power`) but never mapped the 12 *per-pin* 12VHPWR sense lines the TUI's dedicated 12VHPWR tab reads.

Confirmed against `BENCHLAB_Core/Device_BENCHLAB2.cs` in `BenchLab-io/BENCHLAB.BENCHLAB_Service` (dev-blcfe): the C# service emits ShortNames `HPWR{1,2}_W{1..6}_{V,I,P}` for these sense lines, but the TUI reads `HPWR{n}_W{m}_{Voltage,Current,Power}`. Since these keys weren't in `SHORT_NAME_MAP`, they passed through unmapped, and the TUI's `sd.get(f'{key_pfx}_Power', 0.0)` lookups always missed, silently defaulting to 0.0.

Both `ServiceHttpDataSource` and `NamedPipeDataSource` route telemetry through this same function, so both were affected identically — matches the reported behavior exactly.

Fixes #60

## Test plan
- [x] Unit-verified the mapping directly: fed `HPWR1_W1_P`/`_I`/`_V` and `HPWR2_W6_P` through `_normalise_cs_telemetry()` and confirmed correct output keys
- [x] `flake8` clean
- [x] Full `pytest` suite — 200 passed, 42 skipped, no regressions
- [ ] Manual verification against real hardware over service_http/named_pipe (I don't have hardware access — please verify)
- [x] CI passes