### PR TITLE
Bump python-dotenv to 1.2.2 (GHSA-mf9w-mj56-hr94)

### DIFF
--- a/benchlab/requirements.txt
+++ b/benchlab/requirements.txt
@@ -1,6 +1,6 @@
 # Core dependencies with version pins (DEP-1)
 packaging>=23.0,<26.0
-python-dotenv>=1.0.0,<2.0
+python-dotenv>=1.2.2,<2.0
 textual>=0.60,<9.0
 
 # BENCHLAB Serial Handler
@@ -9,8 +9,7 @@ benchlab-pycore>=0.5.1
 # FastAPI Data Source
 fastapi==0.111.1
 uvicorn[standard]==0.24.0
-python-dotenv==1.1.1
-pydantic>=2.0.0  
+pydantic>=2.0.0
 requests>=2.33.1
 
 # MQTT Data Source

--- a/benchlab/restapi/requirements.txt
+++ b/benchlab/restapi/requirements.txt
@@ -1,5 +1,5 @@
 fastapi==0.111.1
 uvicorn[standard]==0.24.0
 pyserial>=3.5
-python-dotenv==1.1.1
+python-dotenv==1.2.2
 pydantic>=2.0.0  # For better data validation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 dependencies = [
     "packaging>=23.0,<26.0",
-    "python-dotenv>=1.0.0,<2.0",
+    "python-dotenv>=1.2.2,<2.0",
     "textual>=0.60,<9.0",
     "benchlab-pycore>=0.5.1",
     "windows-curses>=2.4.1; platform_system=='Windows'",
@@ -48,7 +48,7 @@ restapi = [
     "fastapi==0.111.1",
     "uvicorn[standard]==0.24.0",
     "pyserial>=3.5",
-    "python-dotenv==1.1.1",
+    "python-dotenv==1.2.2",
     "pydantic>=2.0.0",
 ]
 mqtt = [


### PR DESCRIPTION
Resolves the 3 open Dependabot alerts, all the same advisory (**GHSA-mf9w-mj56-hr94**, medium): `python-dotenv < 1.2.2` follows symlinks in `set_key()`.

- `benchlab/requirements.txt` — bump core pin to `>=1.2.2,<2.0`; drop the duplicate `==1.1.1` line
- `benchlab/restapi/requirements.txt` — `==1.2.2`
- `pyproject.toml` — matching bumps in `dependencies` and `restapi` extra

This project only uses `load_dotenv` (never `set_key`), so real exposure was low. `load_dotenv` smoke-tested against 1.2.2.

Alert #2 references a root `requirements.txt` that no longer exists (removed in 22e4359); it will auto-dismiss or can be dismissed manually.

Tracking: #66