### PR TITLE
CI: add Linux coverage to pycore-compat via os matrix (#15)

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -2,6 +2,9 @@ name: pycore compatibility
 
 # Catches drift between pytools and benchlab-pycore's published PyPI API.
 # See issue #9 — issues #6/#7/#8 were caused by silent drift like this.
+#
+# Runs the non-hardware import + test suite on Windows and Linux (issue #15),
+# each against both the pinned pycore and the latest PyPI release.
 on:
   push:
     branches: [dev-pycore, main]
@@ -12,9 +15,14 @@ on:
   workflow_dispatch:
 
 jobs:
-  pinned:
-    name: Import + test against pinned pycore
-    runs-on: windows-latest
+  compat:
+    name: ${{ matrix.pycore }} pycore / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+        pycore: [pinned, latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -22,7 +30,7 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install dependencies (pinned)
+      - name: Install dependencies
         run: |
           pip install -r benchlab/requirements.txt
           pip install -r benchlab/csv_log/requirements.txt
@@ -31,104 +39,16 @@ jobs:
           pip install -r benchlab/vu/requirements.txt
           pip install pytest
 
-      - name: Import smoke test
-        run: >
-          python -c "import benchlab.core, benchlab.core.discovery,
-          benchlab.core.datasource, benchlab.core.shared_serial,
-          benchlab.main, benchlab.launcher, benchlab.menu, benchlab.menu_classic,
-          benchlab.tools, benchlab.sources, benchlab.prefs,
-          benchlab.config.config_client, benchlab.config.config_manager,
-          benchlab.config.diff, benchlab.restapi.telemetry_api,
-          benchlab.mqtt.mqtt_publisher, benchlab.hwinfo.hwinfo_export,
-          benchlab.tui.config, benchlab.tui.tui_core, benchlab.tui.tui_main,
-          benchlab.graph.app, benchlab.graph.ui,
-          benchlab.wigidash.wigidash_manager, benchlab.wigidash.wigidash_usb,
-          benchlab.wigidash.wigidash_device, benchlab.wigidash.wigidash_session,
-          benchlab.wigidash.benchlab_telemetry, benchlab.wigidash.benchlab_fleet,
-          benchlab.wigidash.benchlab_overview, benchlab.wigidash.benchlab_graph,
-          benchlab.vu.vu_server_manager, benchlab.vu.vu_server_config,
-          benchlab.vu.devices, benchlab.vu.vu_tui, benchlab.vu.vu_updater,
-          benchlab.link.link_main"
+      # libusb-package is Windows-only (see wigidash/requirements.txt); on Linux
+      # benchlab.wigidash.wigidash_usb imports pyusb directly and relies on the
+      # runner's system libusb-1.0 for backend discovery.
+      - name: Install pyusb (Linux)
+        if: matrix.os == 'ubuntu-latest'
+        run: pip install pyusb
 
-      - name: Test - core data sources
-        run: pytest tests/test_data_sources.py -v -k "not mqtt"
-
-      - name: Test - csv_log
-        run: pytest tests/test_csv_log.py -v -k "not mqtt"
-
-      - name: Test - REST API server
-        run: pytest benchlab/restapi/test_server.py -v -k "not mqtt"
-
-      - name: Test - TUI rendering
-        run: pytest benchlab/tui/test_tui_core.py -v -k "not mqtt"
-
-      - name: Test - TUI application logic
-        run: pytest benchlab/tui/test_tui_main.py -v -k "not mqtt"
-
-      - name: Test - graph application logic
-        run: pytest benchlab/graph/test_graph.py -v -k "not mqtt"
-
-      - name: Test - hwinfo export
-        run: pytest benchlab/hwinfo/test_hwinfo_export.py -v -k "not mqtt"
-
-      - name: Test - wigidash
-        run: pytest benchlab/wigidash/test_wigidash.py -v -k "not mqtt"
-
-      - name: Test - mqtt publisher
-        run: pytest benchlab/mqtt/test_mqtt_publisher.py -v
-
-      - name: Test - mqtt datasource
-        run: pytest tests/test_mqtt_datasource.py -v
-
-      - name: Test - vu server manager
-        run: pytest benchlab/vu/test_vu_server_manager.py -v
-
-      - name: Test - vu server config
-        run: pytest benchlab/vu/test_vu_server_config.py -v
-
-      - name: Test - vu devices config loading
-        run: pytest benchlab/vu/test_devices.py -v
-
-      - name: Test - vu tui logic
-        run: pytest benchlab/vu/test_vu_tui.py -v
-
-      - name: Test - config diff logic
-        run: pytest benchlab/config/test_diff.py -v
-
-      - name: Test - config manager
-        run: pytest benchlab/config/test_config_manager.py -v
-
-      - name: Test - config client (calibration struct selection)
-        run: pytest benchlab/config/test_config_client.py -v
-
-      - name: Test - launcher bug sweep
-        run: pytest tests/test_launcher.py -v
-
-      - name: Test - interactive menu
-        run: pytest tests/test_menu.py -v
-
-      - name: Test - link
-        run: pytest benchlab/link/test_link_main.py -v
-
-  latest:
-    name: Import + test against latest pycore (PyPI)
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies (latest pycore)
-        run: |
-          pip install -r benchlab/requirements.txt
-          pip install -r benchlab/csv_log/requirements.txt
-          pip install -r benchlab/graph/requirements.txt
-          pip install -r benchlab/wigidash/requirements.txt
-          pip install -r benchlab/vu/requirements.txt
-          pip install pytest
-          pip install --upgrade benchlab-pycore
+      - name: Upgrade to latest pycore (PyPI)
+        if: matrix.pycore == 'latest'
+        run: pip install --upgrade benchlab-pycore
 
       - name: Import smoke test
         run: >

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -349,15 +349,20 @@ def test_picker_screen_source_list_filters_when_tool_selected():
     """Regression: the Data Source column must live-update to only the
     sources compatible with the current Tools selection -- config only
     supports direct/named_pipe, so selecting it must narrow the source
-    list from the full 7 down to those 2."""
-    from benchlab.menu import _build_launcher_app
+    list to those (named_pipe is Windows-only, so just direct off Windows)."""
+    from benchlab.menu import _build_launcher_app, _available_sources
     from textual.widgets import SelectionList
+
+    full_count = len(_available_sources(is_multi=False, supported_sources=None))
+    config_sources = {
+        s for s, _ in _available_sources(
+            is_multi=False, supported_sources=["direct", "named_pipe"])}
 
     async def scenario():
         app = _build_launcher_app([], None)
         async with app.run_test() as pilot:
             await pilot.pause()
-            assert len(app._source_ids) == 7  # unrestricted
+            assert len(app._source_ids) == full_count  # unrestricted
 
             tools = app.query_one("#tools", SelectionList)
             config_option = next(
@@ -365,14 +370,16 @@ def test_picker_screen_source_list_filters_when_tool_selected():
             tools.select(config_option)
             await pilot.pause()
 
-            assert set(app._source_ids) == {"direct", "named_pipe"}
+            assert set(app._source_ids) == config_sources
 
     _run_async(scenario())
 
 
 def test_picker_screen_deselecting_tool_restores_full_source_list():
-    from benchlab.menu import _build_launcher_app
+    from benchlab.menu import _build_launcher_app, _available_sources
     from textual.widgets import SelectionList
+
+    full_count = len(_available_sources(is_multi=False, supported_sources=None))
 
     async def scenario():
         app = _build_launcher_app([], None)
@@ -386,7 +393,7 @@ def test_picker_screen_deselecting_tool_restores_full_source_list():
             tools.deselect(config_option)
             await pilot.pause()
 
-            assert len(app._source_ids) == 7
+            assert len(app._source_ids) == full_count
 
     _run_async(scenario())
 

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -353,7 +353,8 @@ def test_picker_screen_source_list_filters_when_tool_selected():
     from benchlab.menu import _build_launcher_app, _available_sources
     from textual.widgets import SelectionList
 
-    full_count = len(_available_sources(is_multi=False, supported_sources=None))
+    full_count = len(
+        _available_sources(is_multi=False, supported_sources=None))
     config_sources = {
         s for s, _ in _available_sources(
             is_multi=False, supported_sources=["direct", "named_pipe"])}
@@ -379,7 +380,8 @@ def test_picker_screen_deselecting_tool_restores_full_source_list():
     from benchlab.menu import _build_launcher_app, _available_sources
     from textual.widgets import SelectionList
 
-    full_count = len(_available_sources(is_multi=False, supported_sources=None))
+    full_count = len(
+        _available_sources(is_multi=False, supported_sources=None))
 
     async def scenario():
         app = _build_launcher_app([], None)


### PR DESCRIPTION
Closes #15.

## What

- Collapse the two duplicated Windows jobs (`pinned` / `latest`) in `pycore-compat.yml` into one matrixed job: `os: [windows-latest, ubuntu-latest]` x `pycore: [pinned, latest]`. The ~25-step import+test list now has a single source of truth (122 -> 21 lines net).
- `fail-fast: false` so a Linux failure doesn't mask a Windows regression or vice-versa.

## Linux specifics

- Platform-only deps (`windows-curses`, `pywin32`, `libusb-package`) already carry PEP 508 markers, so `pip install -r` skips them on Linux automatically — no per-OS install branching.
- `benchlab.wigidash.wigidash_usb` imports `pyusb` at module scope; added `pip install pyusb` on the Linux leg (uses the runner's system libusb-1.0).
- `benchlab/hwinfo/test_hwinfo_export.py` already self-skips off Windows.
- All `win32*`/`winreg` imports in the modules under test are function-local behind `sys.platform` guards, so the import smoke test is safe on Linux.

## Draft — waiting on the first Linux run

Marked draft so the 4 matrix legs run. Expected: `test_hwinfo_export.py` reports *skipped*, everything else green. If `test_wigidash.py` turns out Windows-coupled, I'll gate it per-OS before marking ready.