### PR TITLE
Fix save/load/reset config on benchlab-pycore 0.6.0

### DIFF
--- a/benchlab/config/config_client.py
+++ b/benchlab/config/config_client.py
@@ -414,20 +414,29 @@ class DirectConfigClient(ConfigClient):
             calibration=cal,
             product_id=self.product_id)
 
+    # CONFIG_ACTION_* codes for UART_CMD_ACTION (opcode 2), the command firmware
+    # actually implements. pycore's old save_config/load_config/reset_config sent
+    # UART_CMD_NVM_CONFIG (opcode 17) and friends -- opcodes no released or
+    # in-development firmware handles -- and were removed in pycore 0.6.0. See
+    # https://github.com/BenchLab-io/benchlab-pycore/issues/11.
+    _CONFIG_ACTION_SAVE = 0
+    _CONFIG_ACTION_LOAD = 1
+    _CONFIG_ACTION_RESET = 2
+
     def save_config(self) -> bool:
         """Save configuration to device flash."""
-        from benchlab_pycore.core.config_io import save_config
-        return save_config(self.ser)
+        from benchlab_pycore.core import send_action
+        return send_action(self.ser, action=self._CONFIG_ACTION_SAVE)
 
     def load_config(self) -> bool:
         """Load configuration from device flash."""
-        from benchlab_pycore.core.config_io import load_config
-        return load_config(self.ser)
+        from benchlab_pycore.core import send_action
+        return send_action(self.ser, action=self._CONFIG_ACTION_LOAD)
 
     def reset_config(self) -> bool:
         """Reset configuration to factory defaults."""
-        from benchlab_pycore.core.config_io import reset_config
-        return reset_config(self.ser)
+        from benchlab_pycore.core import send_action
+        return send_action(self.ser, action=self._CONFIG_ACTION_RESET)
 
     def close(self):
         """Close serial connection."""

--- a/benchlab/config/config_client.py
+++ b/benchlab/config/config_client.py
@@ -414,11 +414,11 @@ class DirectConfigClient(ConfigClient):
             calibration=cal,
             product_id=self.product_id)
 
-    # CONFIG_ACTION_* codes for UART_CMD_ACTION (opcode 2), the command firmware
-    # actually implements. pycore's old save_config/load_config/reset_config sent
-    # UART_CMD_NVM_CONFIG (opcode 17) and friends -- opcodes no released or
-    # in-development firmware handles -- and were removed in pycore 0.6.0. See
-    # https://github.com/BenchLab-io/benchlab-pycore/issues/11.
+    # CONFIG_ACTION_* codes for UART_CMD_ACTION (opcode 2), the command
+    # firmware actually implements. pycore's old save_config/load_config/
+    # reset_config sent UART_CMD_NVM_CONFIG (opcode 17) and friends -- opcodes
+    # no released or in-development firmware handles -- and were removed in
+    # pycore 0.6.0. See benchlab-pycore issue #11.
     _CONFIG_ACTION_SAVE = 0
     _CONFIG_ACTION_LOAD = 1
     _CONFIG_ACTION_RESET = 2

--- a/benchlab/config/test_config_client.py
+++ b/benchlab/config/test_config_client.py
@@ -105,3 +105,62 @@ def test_write_calibration_bl2_data_no_longer_raises_indexerror():
     result = client._dict_to_struct(cal_dict, struct_type)
 
     assert len(result.Ts) == 8
+
+
+# ---------------------------------------------------------------------------
+# save_config / load_config / reset_config -- issue #68
+#
+# benchlab-pycore 0.6.0 removed config_io.save_config/load_config/reset_config
+# (they sent UART_CMD_NVM_CONFIG and friends, opcodes no released or
+# in-development firmware implements -- see benchlab-pycore#11). These three
+# methods now route through send_action(), which mirrors UART_CMD_ACTION
+# (opcode 2), the command firmware actually implements for save/load/reset.
+# ---------------------------------------------------------------------------
+
+def test_save_config_sends_the_save_action(monkeypatch):
+    client = _make_client(BENCHLAB_ORIGINAL_PRODUCT_ID)
+    captured = {}
+
+    def fake_send_action(ser, action):
+        captured["action"] = action
+        return True
+    monkeypatch.setattr("benchlab_pycore.core.send_action", fake_send_action)
+
+    assert client.save_config() is True
+    assert captured["action"] == 0  # CONFIG_ACTION_SAVE
+
+
+def test_load_config_sends_the_load_action(monkeypatch):
+    client = _make_client(BENCHLAB_ORIGINAL_PRODUCT_ID)
+    captured = {}
+
+    def fake_send_action(ser, action):
+        captured["action"] = action
+        return True
+    monkeypatch.setattr("benchlab_pycore.core.send_action", fake_send_action)
+
+    assert client.load_config() is True
+    assert captured["action"] == 1  # CONFIG_ACTION_LOAD
+
+
+def test_reset_config_sends_the_reset_action(monkeypatch):
+    client = _make_client(BENCHLAB_ORIGINAL_PRODUCT_ID)
+    captured = {}
+
+    def fake_send_action(ser, action):
+        captured["action"] = action
+        return True
+    monkeypatch.setattr("benchlab_pycore.core.send_action", fake_send_action)
+
+    assert client.reset_config() is True
+    assert captured["action"] == 2  # CONFIG_ACTION_RESET
+
+
+def test_save_config_propagates_a_failed_send(monkeypatch):
+    """send_action returning False (e.g. another action already pending on
+    the device) must surface as a failed save, not be swallowed."""
+    client = _make_client(BENCHLAB_ORIGINAL_PRODUCT_ID)
+    monkeypatch.setattr(
+        "benchlab_pycore.core.send_action", lambda ser, action: False)
+
+    assert client.save_config() is False

--- a/benchlab/csv_log/requirements.txt
+++ b/benchlab/csv_log/requirements.txt
@@ -1,3 +1,3 @@
 # benchlab/csv_log/requirements.txt
 pyserial>=3.5
-benchlab-pycore>=0.5.1
+benchlab-pycore>=0.6.0

--- a/benchlab/requirements.txt
+++ b/benchlab/requirements.txt
@@ -4,7 +4,7 @@ python-dotenv>=1.2.2,<2.0
 textual>=0.60,<9.0
 
 # BENCHLAB Serial Handler
-benchlab-pycore>=0.5.1
+benchlab-pycore>=0.6.0
 
 # FastAPI Data Source
 fastapi==0.111.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "packaging>=23.0,<26.0",
     "python-dotenv>=1.2.2,<2.0",
     "textual>=0.60,<9.0",
-    "benchlab-pycore>=0.5.1",
+    "benchlab-pycore>=0.6.0",
     "windows-curses>=2.4.1; platform_system=='Windows'",
     "pywin32>=306; platform_system=='Windows'",
 ]
@@ -42,7 +42,7 @@ tui = [
 ]
 csv_log = [
     "pyserial>=3.5",
-    "benchlab-pycore>=0.5.1",
+    "benchlab-pycore>=0.6.0",
 ]
 restapi = [
     "fastapi==0.111.1",


### PR DESCRIPTION
Closes #68.

## Problem

`benchlab-pycore` 0.6.0 removed `config_io.save_config`/`load_config`/`reset_config` (they sent opcodes no released or in-development firmware implements — see [benchlab-pycore#11](https://github.com/BenchLab-io/benchlab-pycore/issues/11)). `DirectConfigClient`'s three lazy-imported wrappers around them raise `ImportError` on upgrade.

These functions could never have succeeded against real hardware — they timed out with no response before this too. The only change is that the failure moved from a silent timeout to an immediate `ImportError`.

## Fix

Routes all three through `send_action()` (`UART_CMD_ACTION`, opcode 2), which firmware actually implements and which pycore's own test suite already exercises as the real save/load/reset path: `CONFIG_ACTION_SAVE=0`, `CONFIG_ACTION_LOAD=1`, `CONFIG_ACTION_RESET=2`.

`config_manager.py`'s `saveToFlash` path needed no change — it already checks `save_config()`'s return value and logs on failure; it will simply start succeeding.

`NamedPipeConfigClient`'s equivalents are unaffected — they talk to the Windows service over a named pipe and never import from `benchlab_pycore.core.config_io`.

Bumps the `benchlab-pycore` floor from `>=0.5.1` to `>=0.6.0` (`pyproject.toml`, both `requirements.txt` files) — required, not just hygiene: everything below 0.6.0 lacks the calibration slot fix and the Tchip scaling fix this floor exists to guarantee.

## Tests

`test_config_client.py` had zero coverage of these three methods before this PR. Added four tests; verified they **fail with the actual `ImportError`** against the real released pycore 0.6.0 with the old code, and pass with the fix.

Local run here hits 36 pre-existing, unrelated failures (`ModuleNotFoundError: No module named '_curses'` — this machine's Python lacks `windows-curses`) confirmed present on unmodified `main` too. `pycore-compat.yml` installs the real dependencies and should run clean; dispatching it against this branch to confirm before merge.
