### PR TITLE
Add service_ws datasource for the C# service /events WebSocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to BENCHLAB PyTools are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows
 [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- `service_ws` data source: consumes the BENCHLAB service `/events`
+  WebSocket event stream (added in the C# service's PR #76). Telemetry is
+  pushed at the service's own poll cadence rather than polled, and device
+  connect/disconnect is reflected without a manual rescan. Output is
+  normalized to the same shape as `service_http`. New CLI flags
+  `--service-ws-url` (default `ws://localhost:8585/events`) and
+  `--service-token`; new optional-dependency group
+  `benchlab-pytools[service_ws]` (`websockets`).
+
 ## [3.0.4] - 2026-08-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -95,17 +95,25 @@ Most tools accept `--source` to choose where telemetry comes from:
 | `mqtt` | Local MQTT broker + publisher, started automatically if needed |
 | `mqtt_custom` | Remote/existing MQTT broker — requires `--mqtt-broker`/`--mqtt-port` |
 | `named_pipe` | Windows BENCHLAB service (`BL_Service`) via named pipes — Windows only |
-| `service_http` | Windows BENCHLAB service HTTP API — requires `--service-url` (default `http://localhost:8585`) |
+| `service_http` | BENCHLAB service HTTP API (polling) — requires `--service-url` (default `http://localhost:8585`) |
+| `service_ws` | BENCHLAB service WebSocket event stream (`/events`, push) — requires `--service-ws-url` (default `ws://localhost:8585/events`); needs the `service_ws` extra |
+
+`service_ws` consumes the same BENCHLAB service as `service_http` but over its
+`/events` WebSocket: telemetry is pushed at the service's own cadence instead of
+polled, and device connect/disconnect is reflected without a manual rescan.
+Install its dependency with `pip install "benchlab-pytools[service_ws]"`.
 
 Common connection flags:
 
 ```
---source SOURCE          direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http
+--source SOURCE          direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http | service_ws
 --api-url URL             FastAPI base URL (default: http://127.0.0.1:8000)
 --api-port PORT           FastAPI port (default: 8000)
 --mqtt-broker HOST         MQTT broker host (default: localhost)
 --mqtt-port PORT           MQTT broker port (default: 1883)
---service-url URL          BENCHLAB Windows service HTTP API URL (default: http://localhost:8585)
+--service-url URL          BENCHLAB service HTTP API URL (default: http://localhost:8585)
+--service-ws-url URL       BENCHLAB service WebSocket event stream URL (default: ws://localhost:8585/events)
+--service-token TOKEN      X-Benchlab-Token for the BENCHLAB service (only if token auth is enabled)
 -i, --interval SECONDS     Refresh interval (default: 1.0)
 ```
 

--- a/benchlab/core/README.md
+++ b/benchlab/core/README.md
@@ -27,8 +27,9 @@ A **DataSource abstraction layer** (`datasource.py`) with multiple implementatio
 | `MQTTDataSource` | `mqtt` / `mqtt_custom` | Subscribes to `<topic_prefix>/+/telemetry` and `<topic_prefix>/+/info` on an MQTT broker via `paho-mqtt`. Resolves `MQTT_PROTOCOL` (v3.1 / v3.1.1 / v5) via the module-level `resolve_mqtt_protocol()` helper. |
 | `NamedPipeDataSource` | `named_pipe` | Windows-only. Talks to the C# BENCHLAB Windows service over named pipes (`BenchlabDiscovery` for device listing, per-device `BenchlabSensorPipe_XX_YYY` pipes for telemetry). Normalizes the C# service's `ShortName`-keyed sensor payloads into the same flat key names Python tools expect, via the module-level `_normalise_cs_telemetry()` helper. |
 | `ServiceHttpDataSource` | `service_http` | REST client for the C# BENCHLAB service's HTTP API (default `http://localhost:8585`). Thin client only — does not start/manage the service. Same telemetry normalization as `NamedPipeDataSource`. |
+| `ServiceWsDataSource` | `service_ws` | Client for the C# BENCHLAB service's `/events` WebSocket stream (default `ws://localhost:8585/events`). Runs an asyncio event loop on a background daemon thread; consumes pushed `hello` / `telemetry` / `device` frames (no poll loop). Same telemetry normalization as `ServiceHttpDataSource` (shared `CS_SHORT_NAME_MAP` / `_normalise_cs_v()`). Requires the `websockets` package (`benchlab-pytools[service_ws]`). |
 
-Each implementation validates its constructor kwargs through a Pydantic model in `config.py` (`SerialConfig`, `FastAPIConfig`, `MQTTConfig`, `NamedPipeConfig`, `ServiceHttpConfig`).
+Each implementation validates its constructor kwargs through a Pydantic model in `config.py` (`SerialConfig`, `FastAPIConfig`, `MQTTConfig`, `NamedPipeConfig`, `ServiceHttpConfig`, `ServiceWsConfig`).
 
 The `create_datasource(source_type, **kwargs)` factory function builds the right class:
 
@@ -109,7 +110,7 @@ Also provides `SharedSerialManager`, a singleton connection pool keyed by port w
 
 ### 10. Config models (`config.py`)
 
-Pydantic models validating each DataSource's constructor kwargs: `SerialConfig`, `FastAPIConfig` (normalizes `base_url` to include a scheme and strips trailing slash), `MQTTConfig`, `NamedPipeConfig`, `ServiceHttpConfig`.
+Pydantic models validating each DataSource's constructor kwargs: `SerialConfig`, `FastAPIConfig` (normalizes `base_url` to include a scheme and strips trailing slash), `MQTTConfig`, `NamedPipeConfig`, `ServiceHttpConfig`, `ServiceWsConfig` (normalizes `url` to a `ws://`/`wss://` scheme ending in `/events`).
 
 ## Package exports (`benchlab/core/__init__.py`)
 
@@ -124,7 +125,7 @@ from benchlab.core import (
 )
 ```
 
-`NamedPipeDataSource` and `ServiceHttpDataSource` live in `datasource.py` but aren't re-exported from `__init__.py`; import them directly from `benchlab.core.datasource` if needed. `BENCHLAB_ORIGINAL_PRODUCT_ID` / `BENCHLAB_BL2_PRODUCT_ID` are re-exported from `benchlab_pycore` (with a fallback to hardcoded `0x10`/`0x11` if pycore isn't installed) so tools can detect device variant without importing pycore directly.
+`NamedPipeDataSource`, `ServiceHttpDataSource`, and `ServiceWsDataSource` live in `datasource.py` but aren't re-exported from `__init__.py`; import them directly from `benchlab.core.datasource` if needed. `BENCHLAB_ORIGINAL_PRODUCT_ID` / `BENCHLAB_BL2_PRODUCT_ID` are re-exported from `benchlab_pycore` (with a fallback to hardcoded `0x10`/`0x11` if pycore isn't installed) so tools can detect device variant without importing pycore directly.
 
 ## How tools use this
 
@@ -144,6 +145,7 @@ from benchlab.core import (
 | `mqtt` / `mqtt_custom` | Distributed/IoT integration | Pub/sub, works with existing MQTT infra | Requires a broker, more moving parts |
 | `named_pipe` | Windows, alongside the C# BENCHLAB service | Multiple tools, no direct serial management | Windows only, requires the service + pywin32 |
 | `service_http` | Windows, alongside the C# BENCHLAB service | HTTP-based, multi-client | Windows-oriented, requires the service running |
+| `service_ws` | Alongside the C# BENCHLAB service, low-latency updates | Push-based (no poll loop), device connect/disconnect events, multi-client | Requires the service running + `websockets` |
 
 ## See Also
 

--- a/benchlab/core/config.py
+++ b/benchlab/core/config.py
@@ -143,3 +143,52 @@ class ServiceHttpConfig(BaseModel):
     @classmethod
     def _strip_trailing_slash(cls, v: str) -> str:
         return v.rstrip('/')
+
+
+class ServiceWsConfig(BaseModel):
+    """Configuration for :class:`ServiceWsDataSource`.
+
+    Connects to the C# BenchLab service WebSocket event stream
+    (``ws://localhost:8585/events``). The service pushes a ``hello`` frame
+    on connect followed by ``telemetry`` and ``device`` frames.
+
+    Attributes
+    ----------
+    url: str
+        WebSocket URL of the C# BenchLab service event stream.
+    token: Optional[str]
+        Bearer token, sent as the ``X-Benchlab-Token`` header. Only needed
+        when the service has ``ApiSettings:Token`` configured. ``None``
+        (the loopback default) means no auth.
+    timeout: float
+        Seconds to wait for the connection to open and the first ``hello``
+        frame. Must be positive.
+    """
+
+    url: str = Field(
+        default="ws://localhost:8585/events",
+        description="WebSocket URL of the C# BenchLab service event stream",
+    )
+    token: Optional[str] = Field(
+        default=None,
+        description="Optional X-Benchlab-Token value")
+    timeout: float = Field(
+        default=5.0,
+        gt=0,
+        description="Connection / first-hello timeout in seconds")
+
+    @field_validator("url")
+    @classmethod
+    def _validate_url(cls, v: str) -> str:
+        """Normalise to a ws:// URL ending in /events."""
+        v = v.strip()
+        if v.startswith("https://"):
+            v = "wss://" + v[len("https://"):]
+        elif v.startswith("http://"):
+            v = "ws://" + v[len("http://"):]
+        elif not v.startswith(("ws://", "wss://")):
+            v = f"ws://{v}"
+        v = v.rstrip('/')
+        if not v.endswith("/events"):
+            v = f"{v}/events"
+        return v

--- a/benchlab/core/datasource.py
+++ b/benchlab/core/datasource.py
@@ -1312,6 +1312,7 @@ class ServiceWsDataSource(DataSource):
 
         self._loop_thread: Optional[threading.Thread] = None
         self._loop: Optional[Any] = None
+        self._main_task: Optional[Any] = None
         self._stop_event = threading.Event()
         self._hello_event = threading.Event()
 
@@ -1353,15 +1354,17 @@ class ServiceWsDataSource(DataSource):
     def disconnect(self) -> None:
         self._stop_event.set()
         loop = self._loop
-        if loop is not None:
+        task = self._main_task
+        if loop is not None and task is not None:
             try:
-                loop.call_soon_threadsafe(loop.stop)
+                loop.call_soon_threadsafe(task.cancel)
             except Exception:
                 pass
         if self._loop_thread and self._loop_thread.is_alive():
-            self._loop_thread.join(timeout=3.0)
+            self._loop_thread.join(timeout=5.0)
         self._loop_thread = None
         self._loop = None
+        self._main_task = None
         with self._lock:
             self._connected = False
             self._devices.clear()
@@ -1399,10 +1402,27 @@ class ServiceWsDataSource(DataSource):
         asyncio.set_event_loop(loop)
         self._loop = loop
         try:
-            loop.run_until_complete(self._main())
-        except Exception as e:  # loop.stop() from disconnect() lands here
+            task = loop.create_task(self._main())
+            self._main_task = task
+            try:
+                loop.run_until_complete(task)
+            except asyncio.CancelledError:
+                pass
+            # Let any lingering tasks (keepalive, recv) unwind cleanly so
+            # closing the loop does not emit "Event loop is closed".
+            pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
+            for t in pending:
+                t.cancel()
+            if pending:
+                loop.run_until_complete(
+                    asyncio.gather(*pending, return_exceptions=True))
+        except Exception as e:
             logger.debug(f"ServiceWs loop ended: {e}")
         finally:
+            try:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            except Exception:
+                pass
             try:
                 loop.close()
             except Exception:
@@ -1415,26 +1435,33 @@ class ServiceWsDataSource(DataSource):
         headers = (
             {"X-Benchlab-Token": self.token} if self.token else None)
         backoff = 1.0
-        while not self._stop_event.is_set():
-            try:
-                async with self._ws_connect(headers) as ws:
-                    backoff = 1.0
-                    self._connected = True
-                    async for raw in ws:
-                        if self._stop_event.is_set():
-                            break
-                        try:
-                            self._dispatch(json.loads(raw))
-                        except Exception as e:
-                            logger.debug(f"Bad service_ws frame: {e}")
-            except Exception as e:
-                logger.debug(f"service_ws connection error: {e}")
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    async with self._ws_connect(headers) as ws:
+                        backoff = 1.0
+                        self._connected = True
+                        async for raw in ws:
+                            if self._stop_event.is_set():
+                                break
+                            try:
+                                self._dispatch(json.loads(raw))
+                            except Exception as e:
+                                logger.debug(f"Bad service_ws frame: {e}")
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    logger.debug(f"service_ws connection error: {e}")
 
+                self._connected = False
+                if self._stop_event.is_set():
+                    break
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 2, 30.0)
+        except asyncio.CancelledError:
+            pass
+        finally:
             self._connected = False
-            if self._stop_event.is_set():
-                break
-            await asyncio.sleep(backoff)
-            backoff = min(backoff * 2, 30.0)
 
     def _ws_connect(self, headers):
         """Call websockets.connect with the header kwarg it supports.

--- a/benchlab/core/datasource.py
+++ b/benchlab/core/datasource.py
@@ -7,6 +7,7 @@ Provides a unified interface for tools to consume telemetry data from:
 - MQTT broker
 - Named pipe (Windows C# BenchLab service)
 - Service HTTP API (C# BenchLab service REST API)
+- Service WebSocket (C# BenchLab service /events event stream)
 """
 
 from .retry import retry, RetryPolicy
@@ -19,7 +20,8 @@ from datetime import datetime, UTC
 from typing import Any, Dict, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from .config import SerialConfig, FastAPIConfig, MQTTConfig
+    from .config import (
+        SerialConfig, FastAPIConfig, MQTTConfig, ServiceWsConfig)
 
 logger = logging.getLogger("benchlab.core.datasource")
 
@@ -656,18 +658,10 @@ class MQTTDataSource(DataSource):
             logger.warning(f"MQTT disconnected unexpectedly (rc={rc})")
 
 
-def _normalise_cs_telemetry(sensors_raw: list) -> Dict[str, Any]:
-    """Normalise a C# SensorList into the flat dict shape the TUI expects.
-
-    The C# service serialises sensors with ShortName keys like 'SYS_P',
-    'T_CHIP', 'FAN1_T', 'V1' etc.  The TUI (and other Python tools) expect
-    keys like 'SYS_Power', 'Chip_Temp', 'Fan1_RPM', 'VIN_0' etc.
-
-    Any key not listed in the mapping is passed through unchanged so that
-    future sensors are visible even without an explicit mapping entry.
-    """
-    # Map C# ShortName → TUI key
-    SHORT_NAME_MAP: Dict[str, str] = {
+# Map C# ShortName → TUI key.  Shared by _normalise_cs_telemetry (C# service
+# REST / named-pipe SensorList) and _normalise_cs_v (C# service /events
+# WebSocket telemetry frames), which both carry the same ShortName keys.
+CS_SHORT_NAME_MAP: Dict[str, str] = {
         # Power summary
         "SYS_P": "SYS_Power",
         "CPU_P": "CPU_Power",
@@ -728,8 +722,24 @@ def _normalise_cs_telemetry(sensors_raw: list) -> Dict[str, Any]:
         **{f"FAN{i}_T": f"Fan{i}_RPM" for i in range(1, 10)},
         **{f"FAN{i}_D": f"Fan{i}_Duty" for i in range(1, 10)},
         "FAN_EXT": "FanExtDuty",
-    }
+}
 
+
+def _cs_sentinel(value: Any) -> bool:
+    """True if a C# sensor value is the invalid sentinel (double.MinValue)."""
+    return isinstance(value, float) and value < -1e300
+
+
+def _normalise_cs_telemetry(sensors_raw: list) -> Dict[str, Any]:
+    """Normalise a C# SensorList into the flat dict shape the TUI expects.
+
+    The C# service serialises sensors with ShortName keys like 'SYS_P',
+    'T_CHIP', 'FAN1_T', 'V1' etc.  The TUI (and other Python tools) expect
+    keys like 'SYS_Power', 'Chip_Temp', 'Fan1_RPM', 'VIN_0' etc.
+
+    Any key not listed in the mapping is passed through unchanged so that
+    future sensors are visible even without an explicit mapping entry.
+    """
     result: Dict[str, Any] = {}
     for s in sensors_raw:
         short = s.get("ShortName") or s.get("shortName", "")
@@ -738,12 +748,28 @@ def _normalise_cs_telemetry(sensors_raw: list) -> Dict[str, Any]:
 
         # Skip sentinel value (double.MinValue serialised as very large
         # negative)
-        if isinstance(value, float) and value < -1e300:
+        if _cs_sentinel(value):
             continue
 
-        tui_key = SHORT_NAME_MAP.get(short, short)
+        tui_key = CS_SHORT_NAME_MAP.get(short, short)
         result[tui_key] = value
 
+    return result
+
+
+def _normalise_cs_v(v: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalise a C# service /events ``telemetry`` frame's ``v`` object.
+
+    The WebSocket frame carries ``v`` as ``{shortName: number}`` — the same
+    ShortName keys as the REST SensorList, minus any invalid/NaN sensor
+    (the service omits those entirely).  Maps through the shared
+    :data:`CS_SHORT_NAME_MAP` so the output matches ``service_http``.
+    """
+    result: Dict[str, Any] = {}
+    for short, value in (v or {}).items():
+        if _cs_sentinel(value):
+            continue
+        result[CS_SHORT_NAME_MAP.get(short, short)] = value
     return result
 
 
@@ -1228,6 +1254,248 @@ class ServiceHttpDataSource(DataSource):
             self._stop_event.wait(self.poll_interval)
 
 
+class ServiceWsDataSource(DataSource):
+    """Data source that consumes the C# BenchLab service WebSocket stream.
+
+    Connects to ``ws://localhost:8585/events`` (the C# service default) and
+    receives pushed frames:
+
+    - ``hello``     — once on connect: service version, poll interval, and
+                      the full device list (== ``GET /devices``).
+    - ``telemetry`` — per connected device, every service poll.
+    - ``device``    — on device connect / disconnect / rename.
+
+    This is a thin client — it does not start or manage the service. If the
+    service is not running, :meth:`connect` fails fast.
+
+    Unlike :class:`ServiceHttpDataSource` there is no poll loop here: an
+    asyncio event loop runs on a background daemon thread and updates the
+    thread-safe telemetry / device caches as frames arrive. Telemetry and
+    device dicts are normalised to the same shape as ``service_http`` via
+    :func:`_normalise_cs_v` / :func:`_normalise_cs_device_info`.
+    """
+
+    DEFAULT_URL = "ws://localhost:8585/events"
+
+    def __init__(
+            self,
+            *,
+            config: Optional["ServiceWsConfig"] = None,
+            url: str = DEFAULT_URL,
+            token: Optional[str] = None,
+            timeout: float = 5.0):
+        """Initialize the service WebSocket data source.
+
+        Args:
+            config: Optional :class:`ServiceWsConfig`. When given, its
+                fields take precedence over the loose kwargs.
+            url: WebSocket URL of the C# service event stream.
+            token: Optional ``X-Benchlab-Token`` value (only needed when the
+                service has token auth configured).
+            timeout: Seconds to wait for the socket to open and the first
+                ``hello`` frame.
+        """
+        from .config import ServiceWsConfig
+
+        if config is None:
+            config = ServiceWsConfig(url=url, token=token, timeout=timeout)
+        self.url = config.url
+        self.token = config.token
+        self.timeout = config.timeout
+
+        self._connected = False
+        self._lock = threading.Lock()
+        self._devices: Dict[str, Dict[str, Any]] = {}
+        self._telemetry: Dict[str, Dict[str, Any]] = {}
+        self._service_version: Optional[str] = None
+        self._poll_interval_ms: Optional[int] = None
+
+        self._loop_thread: Optional[threading.Thread] = None
+        self._loop: Optional[Any] = None
+        self._stop_event = threading.Event()
+        self._hello_event = threading.Event()
+
+        try:
+            import websockets
+            self._websockets = websockets
+        except ImportError:
+            logger.error(
+                "websockets library not available — "
+                "pip install 'benchlab-pytools[service_ws]'")
+            self._websockets = None
+
+    def connect(self) -> bool:
+        """Open the WebSocket and wait for the first ``hello`` frame."""
+        if self._websockets is None:
+            return False
+
+        self._stop_event.clear()
+        self._hello_event.clear()
+        self._loop_thread = threading.Thread(
+            target=self._run_loop, daemon=True)
+        self._loop_thread.start()
+
+        if not self._hello_event.wait(timeout=self.timeout):
+            logger.error(
+                f"No 'hello' frame from BenchLab service at {self.url} "
+                f"within {self.timeout}s.\n"
+                "  Make sure the BenchLab Windows service is running and "
+                "its WebSocket endpoint is reachable."
+            )
+            self.disconnect()
+            return False
+
+        logger.info(
+            f"Connected to BenchLab service WebSocket at {self.url} "
+            f"(service {self._service_version})")
+        return True
+
+    def disconnect(self) -> None:
+        self._stop_event.set()
+        loop = self._loop
+        if loop is not None:
+            try:
+                loop.call_soon_threadsafe(loop.stop)
+            except Exception:
+                pass
+        if self._loop_thread and self._loop_thread.is_alive():
+            self._loop_thread.join(timeout=3.0)
+        self._loop_thread = None
+        self._loop = None
+        with self._lock:
+            self._connected = False
+            self._devices.clear()
+            self._telemetry.clear()
+        logger.info("Disconnected from BenchLab service WebSocket")
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def list_devices(self) -> List[Dict[str, Any]]:
+        with self._lock:
+            return list(self._devices.values())
+
+    def get_telemetry(self, uid: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            return self._telemetry.get(uid)
+
+    def get_device_info(self, uid: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            return self._devices.get(uid)
+
+    @property
+    def source_type(self) -> str:
+        return "service_ws"
+
+    # ------------------------------------------------------------------
+    # Internal — background event loop
+    # ------------------------------------------------------------------
+
+    def _run_loop(self) -> None:
+        """Thread target: own an asyncio loop and run the client coroutine."""
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        self._loop = loop
+        try:
+            loop.run_until_complete(self._main())
+        except Exception as e:  # loop.stop() from disconnect() lands here
+            logger.debug(f"ServiceWs loop ended: {e}")
+        finally:
+            try:
+                loop.close()
+            except Exception:
+                pass
+
+    async def _main(self) -> None:
+        """Connect, read frames, reconnect with backoff until stopped."""
+        import asyncio
+
+        headers = (
+            {"X-Benchlab-Token": self.token} if self.token else None)
+        backoff = 1.0
+        while not self._stop_event.is_set():
+            try:
+                async with self._ws_connect(headers) as ws:
+                    backoff = 1.0
+                    self._connected = True
+                    async for raw in ws:
+                        if self._stop_event.is_set():
+                            break
+                        try:
+                            self._dispatch(json.loads(raw))
+                        except Exception as e:
+                            logger.debug(f"Bad service_ws frame: {e}")
+            except Exception as e:
+                logger.debug(f"service_ws connection error: {e}")
+
+            self._connected = False
+            if self._stop_event.is_set():
+                break
+            await asyncio.sleep(backoff)
+            backoff = min(backoff * 2, 30.0)
+
+    def _ws_connect(self, headers):
+        """Call websockets.connect with the header kwarg it supports.
+
+        websockets >=14 renamed ``extra_headers`` to ``additional_headers``.
+        """
+        kwargs: Dict[str, Any] = {"open_timeout": self.timeout,
+                                  "ping_interval": 20}
+        if headers:
+            try:
+                return self._websockets.connect(
+                    self.url, additional_headers=headers, **kwargs)
+            except TypeError:
+                return self._websockets.connect(
+                    self.url, extra_headers=headers, **kwargs)
+        return self._websockets.connect(self.url, **kwargs)
+
+    def _dispatch(self, msg: Dict[str, Any]) -> None:
+        """Apply one decoded frame to the caches."""
+        mtype = msg.get("type")
+
+        if mtype == "hello":
+            devices = msg.get("devices", []) or []
+            with self._lock:
+                self._devices.clear()
+                for d in devices:
+                    uid = d.get("uid", "")
+                    if uid:
+                        self._devices[uid] = _normalise_cs_device_info(d)
+                self._service_version = msg.get("serviceVersion")
+                self._poll_interval_ms = msg.get("pollIntervalMs")
+                self._connected = True
+            self._hello_event.set()
+
+        elif mtype == "telemetry":
+            uid = msg.get("uid", "")
+            if not uid:
+                return
+            norm = _normalise_cs_v(msg.get("v", {}))
+            norm["timestamp"] = msg.get(
+                "ts", datetime.now(UTC).isoformat())
+            with self._lock:
+                self._telemetry[uid] = norm
+
+        elif mtype == "device":
+            uid = msg.get("uid", "")
+            if not uid:
+                return
+            event = msg.get("event")
+            with self._lock:
+                if event == "disconnected":
+                    self._devices.pop(uid, None)
+                    self._telemetry.pop(uid, None)
+                else:  # connected | renamed
+                    dev = msg.get("device") or {"uid": uid}
+                    self._devices[uid] = _normalise_cs_device_info(dev)
+
+        else:  # subscribed | pong | error
+            logger.debug(f"service_ws control frame: {msg}")
+
+
 def create_datasource(
     source_type: str,
     **kwargs
@@ -1244,6 +1512,8 @@ def create_datasource(
                      'named_pipe'    - C# BenchLab service named pipes
                                        (Windows only)
                      'service_http'  - C# BenchLab service HTTP API
+                     'service_ws'    - C# BenchLab service WebSocket
+                                       event stream (/events)
         **kwargs: Arguments passed to the data source constructor
 
     Returns:
@@ -1266,5 +1536,7 @@ def create_datasource(
         return NamedPipeDataSource(**kwargs)
     elif source_type == 'service_http':
         return ServiceHttpDataSource(**kwargs)
+    elif source_type == 'service_ws':
+        return ServiceWsDataSource(**kwargs)
     else:
         raise ValueError(f"Unknown data source type: {source_type}")

--- a/benchlab/core/datasource_manager.py
+++ b/benchlab/core/datasource_manager.py
@@ -25,7 +25,8 @@ ALL_SOURCE_TYPES = (
     "mqtt",
     "mqtt_custom",
     "named_pipe",
-    "service_http")
+    "service_http",
+    "service_ws")
 
 
 class DataSourceManager:
@@ -277,6 +278,10 @@ class DataSourceManager:
             base_url = self.datasource_kwargs.get(
                 'base_url', 'http://localhost:8585')
             return f"BenchLab service HTTP API at {base_url}"
+        elif self.source_type == 'service_ws':
+            url = self.datasource_kwargs.get(
+                'url', 'ws://localhost:8585/events')
+            return f"BenchLab service events (WS) at {url}"
         else:
             return f"{self.source_type} datasource"
 
@@ -336,6 +341,14 @@ class DataSourceManager:
             # ServiceHttpDataSource accepts: base_url, timeout, poll_interval
             kwargs = {}
             for key in ('base_url', 'timeout', 'poll_interval'):
+                if key in self.datasource_kwargs:
+                    kwargs[key] = self.datasource_kwargs[key]
+            return kwargs
+
+        elif self.source_type == 'service_ws':
+            # ServiceWsDataSource accepts: url, token, timeout
+            kwargs = {}
+            for key in ('url', 'token', 'timeout'):
                 if key in self.datasource_kwargs:
                     kwargs[key] = self.datasource_kwargs[key]
             return kwargs

--- a/benchlab/csv_log/README.md
+++ b/benchlab/csv_log/README.md
@@ -89,7 +89,7 @@ python -m benchlab -logfleet
 # Custom interval
 python -m benchlab -logfleet -i 0.5
 
-# Choose a data source (direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http)
+# Choose a data source (direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http | service_ws)
 python -m benchlab -logfleet --source fastapi --api-url http://127.0.0.1:8000
 python -m benchlab -logfleet --source mqtt --mqtt-broker localhost --mqtt-port 1883
 ```

--- a/benchlab/graph/README.md
+++ b/benchlab/graph/README.md
@@ -55,7 +55,7 @@ python -m benchlab -graph
 # Custom interval
 python -m benchlab -graph -i 0.5
 
-# Choose a data source (direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http)
+# Choose a data source (direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http | service_ws)
 python -m benchlab -graph --source fastapi --api-url http://127.0.0.1:8000
 python -m benchlab -graph --source mqtt --mqtt-broker localhost --mqtt-port 1883
 ```

--- a/benchlab/hwinfo/README.md
+++ b/benchlab/hwinfo/README.md
@@ -93,7 +93,7 @@ python -m benchlab -hwinfo
 # Custom interval
 python -m benchlab -hwinfo -i 2
 
-# Choose a data source (direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http)
+# Choose a data source (direct | fastapi | fastapi_custom | mqtt | mqtt_custom | named_pipe | service_http | service_ws)
 python -m benchlab -hwinfo --source fastapi --api-url http://127.0.0.1:8000
 python -m benchlab -hwinfo --source mqtt --mqtt-broker localhost --mqtt-port 1883
 ```

--- a/benchlab/main.py
+++ b/benchlab/main.py
@@ -101,7 +101,7 @@ def get_parser() -> argparse.ArgumentParser:
         "--source",
         help=(
             "Data source: direct | fastapi | fastapi_custom | mqtt | "
-            "mqtt_custom | named_pipe | service_http"),
+            "mqtt_custom | named_pipe | service_http | service_ws"),
         choices=[
             "direct",
             "fastapi",
@@ -109,7 +109,8 @@ def get_parser() -> argparse.ArgumentParser:
             "mqtt",
             "mqtt_custom",
             "named_pipe",
-            "service_http"],
+            "service_http",
+            "service_ws"],
         default=None,
         metavar="SOURCE")
     parser.add_argument(
@@ -133,6 +134,18 @@ def get_parser() -> argparse.ArgumentParser:
         help=(
             "C# BenchLab service HTTP API URL "
             "(default: http://localhost:8585)"))
+    parser.add_argument(
+        "--service-ws-url",
+        default="ws://localhost:8585/events",
+        dest="service_ws_url",
+        help=(
+            "C# BenchLab service WebSocket event stream URL "
+            "(default: ws://localhost:8585/events)"))
+    parser.add_argument(
+        "--service-token",
+        default=None,
+        dest="service_token",
+        help="X-Benchlab-Token for the C# service (if token auth is enabled)")
     parser.add_argument("-vu", action="store_true",
                         help="Launch VU analog dials")
     parser.add_argument("-vuconfig", action="store_true",
@@ -233,6 +246,21 @@ def _setup_source_from_args(args) -> bool:
         parsed = urllib.parse.urlparse(service_url)
         ready = check_and_setup_source(
             "service_http",
+            host=parsed.hostname or "localhost",
+            port=parsed.port or 8585,
+        )
+
+    elif source == "service_ws":
+        ws_url = getattr(args, "service_ws_url", None) or os.environ.get(
+            "BENCHLAB_SERVICE_WS_URL", "ws://localhost:8585/events")
+        os.environ["BENCHLAB_SERVICE_WS_URL"] = ws_url
+        token = getattr(args, "service_token", None)
+        if token:
+            os.environ["BENCHLAB_SERVICE_TOKEN"] = token
+        import urllib.parse
+        parsed = urllib.parse.urlparse(ws_url)
+        ready = check_and_setup_source(
+            "service_ws",
             host=parsed.hostname or "localhost",
             port=parsed.port or 8585,
         )

--- a/benchlab/menu.py
+++ b/benchlab/menu.py
@@ -64,6 +64,10 @@ SOURCE_LABELS: Dict[str, str] = {
     "service_http": (
         f"BenchLab service - HTTP API (port {SERVICE_HTTP_DEFAULT_PORT})"
     ),
+    "service_ws": (
+        f"BenchLab service - WebSocket events "
+        f"(port {SERVICE_HTTP_DEFAULT_PORT})"
+    ),
 }
 
 SOURCE_ORDER = [
@@ -73,7 +77,8 @@ SOURCE_ORDER = [
     "mqtt",
     "mqtt_custom",
     "named_pipe",
-    "service_http"]
+    "service_http",
+    "service_ws"]
 
 PROVIDER_LABELS: Dict[str, str] = {
     "fastapi": "FastAPI Server - REST API + WebSocket on port 8000",
@@ -608,6 +613,15 @@ def _setup_source(source_type: str) -> bool:
         setup_kwargs = {"host": parsed.hostname or "localhost",
                         "port": parsed.port or SERVICE_HTTP_DEFAULT_PORT}
 
+    elif source_type == "service_ws":
+        import urllib.parse
+        ws_url = os.environ.get(
+            "BENCHLAB_SERVICE_WS_URL",
+            f"ws://localhost:{SERVICE_HTTP_DEFAULT_PORT}/events")
+        parsed = urllib.parse.urlparse(ws_url)
+        setup_kwargs = {"host": parsed.hostname or "localhost",
+                        "port": parsed.port or SERVICE_HTTP_DEFAULT_PORT}
+
     ready = check_and_setup_source(source_type, **setup_kwargs)
     _last_source_params[source_type] = remembered
     return ready
@@ -665,7 +679,7 @@ def _launch(tool_ids: List[str], source: str) -> None:
     _last_source_params.clear()
     if not _setup_source(source):
         print(f"\n  Could not set up '{source}' data source.")
-        if source in ("named_pipe", "service_http"):
+        if source in ("named_pipe", "service_http", "service_ws"):
             print(
                 "  Start the BenchLab Windows service (BL_Service.exe) "
                 "and try again.")

--- a/benchlab/menu_classic.py
+++ b/benchlab/menu_classic.py
@@ -248,6 +248,10 @@ def _build_source_menu(is_multi: bool,
     all_sources.append(
         (f"BenchLab service - HTTP API (port {SERVICE_HTTP_DEFAULT_PORT})",
          "service_http"))
+    all_sources.append(
+        (f"BenchLab service - WebSocket events "
+         f"(port {SERVICE_HTTP_DEFAULT_PORT})",
+         "service_ws"))
 
     # Filter by supported_sources if provided
     if supported_sources is not None:
@@ -343,12 +347,20 @@ def step3_select_source(tool_ids: List[str], tool_names: List[str]) -> None:
         parsed = urllib.parse.urlparse(svc_url)
         setup_kwargs = {"host": parsed.hostname or "localhost",
                         "port": parsed.port or SERVICE_HTTP_DEFAULT_PORT}
+    elif source_type == "service_ws":
+        import urllib.parse
+        ws_url = os.environ.get(
+            "BENCHLAB_SERVICE_WS_URL",
+            f"ws://localhost:{SERVICE_HTTP_DEFAULT_PORT}/events")
+        parsed = urllib.parse.urlparse(ws_url)
+        setup_kwargs = {"host": parsed.hostname or "localhost",
+                        "port": parsed.port or SERVICE_HTTP_DEFAULT_PORT}
 
     source_ready = check_and_setup_source(source_type, **setup_kwargs)
 
     if not source_ready:
         print(f"\n  ✗ Could not set up {source_type} data source.")
-        if source_type in ("named_pipe", "service_http"):
+        if source_type in ("named_pipe", "service_http", "service_ws"):
             print(
                 "  → Start the BenchLab Windows service (BL_Service.exe) "
                 "and try again.")

--- a/benchlab/sources.py
+++ b/benchlab/sources.py
@@ -340,6 +340,7 @@ def check_and_setup_source(source_type: str, **kwargs) -> bool:
         'mqtt'         — MQTT broker + publisher
         'named_pipe'   — C# BenchLab service named pipes (Windows only)
         'service_http' — C# BenchLab service HTTP API
+        'service_ws'   — C# BenchLab service WebSocket event stream
     """
     if source_type == "direct":
         os.environ["BENCHLAB_DATA_SOURCE"] = "direct"
@@ -445,6 +446,32 @@ def check_and_setup_source(source_type: str, **kwargs) -> bool:
             f"http://{host}:{port} {devices_msg}")
         os.environ["BENCHLAB_DATA_SOURCE"] = "service_http"
         os.environ["BENCHLAB_SERVICE_URL"] = f"http://{host}:{port}"
+        return True
+
+    if source_type == "service_ws":
+        # The WebSocket endpoint lives in the same C# process as the REST
+        # API, so the plain HTTP /health probe is the readiness check.
+        port = kwargs.get("port", SERVICE_HTTP_DEFAULT_PORT)
+        host = kwargs.get("host", "localhost")
+
+        if not _service_http_health(host, port):
+            logger.error(
+                f"BenchLab service not detected at http://{host}:{port}.\n"
+                "  → Make sure the BenchLab Windows service (BL_Service) "
+                "is running.\n"
+                "  → The service (REST + WebSocket) listens on port 8585 "
+                "by default."
+            )
+            return False
+
+        devices_msg = "with device(s)" if _service_http_devices_available(
+            host, port) else "but no devices detected"
+        logger.info(
+            f"BenchLab service WebSocket ready at "
+            f"ws://{host}:{port}/events {devices_msg}")
+        os.environ["BENCHLAB_DATA_SOURCE"] = "service_ws"
+        os.environ["BENCHLAB_SERVICE_WS_URL"] = (
+            f"ws://{host}:{port}/events")
         return True
 
     if source_type == "fastapi_custom":

--- a/benchlab/tui/README.md
+++ b/benchlab/tui/README.md
@@ -158,10 +158,12 @@ Running `python -m benchlab` with no flags at all also launches the interactive 
 ### Configuration
 
 - `-i`, `--interval` - Telemetry refresh interval in seconds (default: `1.0`)
-- `--source` - Data source to read telemetry from: `direct` (serial, default), `fastapi`, `fastapi_custom`, `mqtt`, `named_pipe`, or `service_http`
+- `--source` - Data source to read telemetry from: `direct` (serial, default), `fastapi`, `fastapi_custom`, `mqtt`, `named_pipe`, `service_http`, or `service_ws`
 - `--api-port` - FastAPI server port, used when `--source fastapi` (default: `8000`)
 - `--mqtt-broker`, `--mqtt-port` - MQTT broker host/port, used when `--source mqtt` (defaults: `localhost` / `1883`)
 - `--service-url` - C# BenchLab service HTTP API URL, used when `--source service_http` (default: `http://localhost:8585`)
+- `--service-ws-url` - C# BenchLab service WebSocket event stream URL, used when `--source service_ws` (default: `ws://localhost:8585/events`)
+- `--service-token` - `X-Benchlab-Token` for the C# BenchLab service, if token auth is enabled
 
 Example:
 

--- a/benchlab/tui/tui_main.py
+++ b/benchlab/tui/tui_main.py
@@ -146,6 +146,14 @@ class TUIApplication:
             datasource_kwargs['base_url'] = service_url
             datasource_kwargs['timeout'] = 5.0
 
+        elif self.source_type == 'service_ws':
+            datasource_kwargs['url'] = getattr(
+                args, 'service_ws_url', None) or 'ws://localhost:8585/events'
+            token = getattr(args, 'service_token', None)
+            if token:
+                datasource_kwargs['token'] = token
+            datasource_kwargs['timeout'] = 5.0
+
         self.datasource_manager = DataSourceManager(
             source_type=self.source_type,
             stats_callback=stats_callback,
@@ -381,9 +389,20 @@ if __name__ == "__main__":
             'fastapi_custom',
             'mqtt',
             'named_pipe',
-            'service_http'],
+            'service_http',
+            'service_ws'],
         default='direct',
         help='Data source type')
+    parser.add_argument(
+        '--service-ws-url',
+        default='ws://localhost:8585/events',
+        dest='service_ws_url',
+        help='C# BenchLab service WebSocket event stream URL')
+    parser.add_argument(
+        '--service-token',
+        default=None,
+        dest='service_token',
+        help='X-Benchlab-Token for the C# service (if token auth enabled)')
     parser.add_argument('--api-port', type=int, default=8000, dest='api_port',
                         help='FastAPI server port')
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ mqtt = [
     "amqtt>=0.12.0,<0.13.0",
     "pyyaml>=6.0,<7.0",
 ]
+service_ws = [
+    "websockets>=13.0,<16.0",
+]
 graph = [
     "dearpygui>=2.1.1",
     "pyserial>=3.5",
@@ -82,7 +85,7 @@ wigidash = [
     "libusb-package>=1.0.26.1; sys_platform == 'win32'",
 ]
 all = [
-    "benchlab-pytools[tui,csv_log,restapi,mqtt,graph,hwinfo,vu,wigidash]",
+    "benchlab-pytools[tui,csv_log,restapi,mqtt,service_ws,graph,hwinfo,vu,wigidash]",
 ]
 
 [project.urls]

--- a/tests/test_service_ws_datasource.py
+++ b/tests/test_service_ws_datasource.py
@@ -1,0 +1,161 @@
+"""Non-hardware tests for the ``service_ws`` data source.
+
+Exercises ServiceWsDataSource's frame-dispatch logic and the
+ServiceWsConfig URL validator directly — no running BenchLab service or
+hardware required (unlike the integration tests in
+tests/test_data_sources.py). Frame shapes follow
+bl-benchlab-service/docs/events.md.
+"""
+
+import pytest
+
+from benchlab.core.config import ServiceWsConfig
+from benchlab.core.datasource import (
+    ServiceWsDataSource,
+    _normalise_cs_v,
+    create_datasource,
+)
+
+try:
+    import websockets  # noqa: F401
+    HAS_WS = True
+except ImportError:
+    HAS_WS = False
+
+pytestmark = pytest.mark.skipif(
+    not HAS_WS, reason="websockets not available")
+
+
+HELLO = {
+    "type": "hello",
+    "serviceVersion": "2.5.1",
+    "pollIntervalMs": 1000,
+    "devices": [
+        {
+            "uid": "UID1",
+            "name": "BENCHLAB",
+            "productId": 0x11,
+            "port": "COM5",
+            "status": "CONNECTED",
+            "sensorCount": 66,
+            "firmwareVersion": 6,
+        }
+    ],
+}
+
+TELEMETRY = {
+    "type": "telemetry",
+    "uid": "UID1",
+    "ts": "2026-09-03T12:00:00.100Z",
+    "v": {"EPS1_P": 96.3, "TS1": 31.2, "ATX12V_V": 12.02, "V1": 3.31},
+}
+
+
+def _ds():
+    return ServiceWsDataSource(url="ws://localhost:8585/events")
+
+
+def test_hello_populates_devices():
+    ds = _ds()
+    ds._dispatch(HELLO)
+
+    devices = ds.list_devices()
+    assert len(devices) == 1
+    dev = devices[0]
+    assert dev["uid"] == "UID1"
+    assert dev["ProductId"] == 0x11
+    assert dev["variant"] == "BL2"
+    assert ds.is_connected()
+    assert ds._hello_event.is_set()
+    assert ds._service_version == "2.5.1"
+
+
+def test_telemetry_is_normalised():
+    ds = _ds()
+    ds._dispatch(HELLO)
+    ds._dispatch(TELEMETRY)
+
+    tele = ds.get_telemetry("UID1")
+    assert tele is not None
+    # ShortName keys mapped to TUI keys via the shared CS_SHORT_NAME_MAP
+    assert tele["EPS1_Power"] == 96.3
+    assert tele["TS_1"] == 31.2
+    assert tele["ATX12V_Voltage"] == 12.02
+    assert tele["VIN_0"] == 3.31
+    assert tele["timestamp"] == "2026-09-03T12:00:00.100Z"
+
+
+def test_telemetry_omits_absent_sensors():
+    ds = _ds()
+    ds._dispatch(HELLO)
+    ds._dispatch(TELEMETRY)
+
+    tele = ds.get_telemetry("UID1")
+    # Only the four sensors present in v (+ timestamp) should be there
+    assert set(tele) == {
+        "EPS1_Power", "TS_1", "ATX12V_Voltage", "VIN_0", "timestamp"}
+
+
+def test_device_disconnected_removes_uid():
+    ds = _ds()
+    ds._dispatch(HELLO)
+    ds._dispatch(TELEMETRY)
+    ds._dispatch({
+        "type": "device",
+        "uid": "UID1",
+        "event": "disconnected",
+        "device": HELLO["devices"][0],
+    })
+
+    assert ds.list_devices() == []
+    assert ds.get_telemetry("UID1") is None
+
+
+def test_device_connected_adds_uid():
+    ds = _ds()
+    ds._dispatch(HELLO)
+    ds._dispatch({
+        "type": "device",
+        "uid": "UID2",
+        "event": "connected",
+        "device": {"uid": "UID2", "productId": 0x10, "port": "COM7"},
+    })
+
+    uids = {d["uid"] for d in ds.list_devices()}
+    assert uids == {"UID1", "UID2"}
+    dev2 = ds.get_device_info("UID2")
+    assert dev2["variant"] == "ORIGINAL"
+
+
+def test_control_frames_do_not_raise():
+    ds = _ds()
+    ds._dispatch({"type": "subscribed", "all": True, "uids": []})
+    ds._dispatch({"type": "pong", "ts": "2026-09-03T12:00:00.100Z"})
+    ds._dispatch({"type": "error", "error": "invalid-argument",
+                  "message": "nope"})
+
+
+def test_normalise_cs_v_skips_sentinel():
+    out = _normalise_cs_v({"EPS1_P": 12.0, "TS1": -3.0e300})
+    assert out == {"EPS1_Power": 12.0}
+
+
+# ----------------------------------------------------------------------
+# Config URL validation
+# ----------------------------------------------------------------------
+
+@pytest.mark.parametrize("raw, expected", [
+    ("ws://localhost:8585/events", "ws://localhost:8585/events"),
+    ("http://localhost:8585", "ws://localhost:8585/events"),
+    ("https://host:9000", "wss://host:9000/events"),
+    ("localhost:8585", "ws://localhost:8585/events"),
+    ("ws://localhost:8585/events/", "ws://localhost:8585/events"),
+])
+def test_config_url_validator(raw, expected):
+    assert ServiceWsConfig(url=raw).url == expected
+
+
+def test_factory_creates_service_ws():
+    ds = create_datasource("service_ws", url="ws://localhost:8585/events")
+    assert isinstance(ds, ServiceWsDataSource)
+    assert ds.source_type == "service_ws"


### PR DESCRIPTION
Closes #70

## What

Adds a `service_ws` datasource that consumes the C# BenchLab service's WebSocket event stream (`ws://localhost:8585/events`, added in `bl-benchlab-service` PR #76).

The service pushes a `hello` frame on connect (version, poll interval, device list), then streams `telemetry` frames (per connected device, per poll) and `device` frames (connect/disconnect/rename).

### Why over `service_http`

- Push-based — telemetry at the service's native cadence, no client poll loop.
- Device connect/disconnect handled without a manual rescan.

## Changes

- **`ServiceWsDataSource`** (`benchlab/core/datasource.py`) — asyncio `websockets` client on a background daemon thread, reconnect with exponential backoff, thread-safe telemetry/device caches. `CS_SHORT_NAME_MAP` extracted to module scope; new `_normalise_cs_v()` so telemetry comes out in the same TUI-key shape as `service_http` (`EPS1_Power`, `VIN_0`, ...).
- **`ServiceWsConfig`** (`benchlab/core/config.py`) — `ws://` URL validator (`http`->`ws`, appends `/events`).
- Wiring: `DataSourceManager` (`ALL_SOURCE_TYPES`, kwarg filter, description), `create_datasource`, `--source service_ws` + `--service-ws-url` / `--service-token` in `main.py` and `tui/tui_main.py`, `sources.check_and_setup_source` (reuses the HTTP `/health` probe — WS shares the C# process), interactive menus.
- **`pyproject.toml`** — new optional-deps group `service_ws = ["websockets>=13,<16"]`, added to `all`.
- **Tests** — `tests/test_service_ws_datasource.py` (13, no hardware): frame dispatch, normalization, device add/remove, config URL validator, factory.

## Verification

- `flake8` clean; new unit tests pass.
- Manual end-to-end against the real service still to be done (run the `bl-benchlab-service` installer, then `python -m benchlab -tui --source service_ws`).