### PR TITLE
Release v3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to BENCHLAB PyTools are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows
 [SemVer](https://semver.org/).
 
-## [Unreleased]
+## [3.1.0] - 2026-09-08
 
 ### Added
 - `service_ws` data source: consumes the BENCHLAB service `/events`
@@ -112,8 +112,9 @@ Snapshot of the codebase at the point packaging work began. Interactive
 menu (prompt_toolkit-based), TUI, CSV logger, FastAPI server, graph, HWiNFO
 export, MQTT publisher, VU dials, WigiDash, and config import/export tools,
 sharing a common data-source layer (direct serial, FastAPI, MQTT, named
-pipe, service HTTP).
+pipe, service HTTP, service WebSocket).
 
+[3.1.0]: https://github.com/BenchLab-io/benchlab-pytools/compare/v3.0.4...v3.1.0
 [3.0.4]: https://github.com/BenchLab-io/benchlab-pytools/compare/v3.0.3...v3.0.4
 [3.0.3]: https://github.com/BenchLab-io/benchlab-pytools/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/BenchLab-io/benchlab-pytools/compare/v3.0.1...v3.0.2

--- a/benchlab/__init__.py
+++ b/benchlab/__init__.py
@@ -2,4 +2,4 @@
 BENCHLAB Telemetry Package
 """
 
-__version__ = "3.0.4"
+__version__ = "3.1.0"


### PR DESCRIPTION
Version bump to `3.1.0` and CHANGELOG finalization.

## 3.1.0 — Added

- **`service_ws` data source** — consumes the BENCHLAB service `/events` WebSocket event stream (added in the C# service's PR #76). Telemetry is pushed at the service's own poll cadence rather than polled, and device connect/disconnect is reflected without a manual rescan. Output is normalized to the same shape as `service_http`. New CLI flags `--service-ws-url` / `--service-token`; new optional-dependency group `benchlab-pytools[service_ws]` (`websockets`).

Feature work landed in #71 (closes #70) and was verified end to end against a running `BL_Service`.

## Release steps

After merge, push the tag to trigger the `release` workflow (build + test on Windows, publish to PyPI, GitHub release):

```
git checkout main && git pull
git tag v3.1.0 && git push origin v3.1.0
```