### PR TITLE
Prevent disconnected remote TUIs from probing local serial ports

### DIFF
--- a/benchlab/tui/test_tui_main.py
+++ b/benchlab/tui/test_tui_main.py
@@ -5,6 +5,8 @@ DataSourceManager directly.
 """
 
 import types
+
+import pytest
 from unittest.mock import MagicMock
 
 from benchlab.tui.tui_main import TUIApplication
@@ -74,3 +76,38 @@ def test_scan_local_fleet_survives_none_port_when_disconnected():
     fleet = app._scan_local_fleet()
 
     assert fleet == []
+
+
+@pytest.mark.parametrize("source", [
+    "fastapi", "fastapi_custom", "mqtt", "mqtt_custom",
+    "named_pipe", "service_http", "service_ws",
+])
+def test_remote_fleet_refresh_never_probes_serial(source):
+    app = _make_app()
+    app.source_type = source
+    app.datasource_manager.is_connected.return_value = True
+    app.datasource_manager.list_devices.return_value = {
+        "REMOTE-UID": {"port": "remote", "variant": "BL2"},
+    }
+    app._refresh_fleet_cache()
+    assert [device["uid"] for device in app.fleet_cache] == ["REMOTE-UID"]
+    app.datasource_manager.list_devices.assert_called_once_with()
+
+    # A disconnect clears the remote list without discovering local devices.
+    app.datasource_manager.is_connected.return_value = False
+    app.last_fleet_refresh = 0
+    app._refresh_fleet_cache()
+    assert app.fleet_cache == []
+    app.datasource_manager.discover_devices.assert_not_called()
+    app.datasource_manager.list_devices.assert_called_once_with()
+
+
+def test_direct_fleet_refresh_still_discovers_devices():
+    app = _make_app()
+    app.datasource_manager.is_connected.return_value = False
+    app.datasource_manager.discover_devices.return_value = [
+        {"uid": "LOCAL-UID", "port": "COM5", "fw": 2},
+    ]
+    app._refresh_fleet_cache()
+    app.datasource_manager.discover_devices.assert_called_once_with()
+    assert [device["uid"] for device in app.fleet_cache] == ["LOCAL-UID"]

--- a/benchlab/tui/tui_main.py
+++ b/benchlab/tui/tui_main.py
@@ -300,12 +300,15 @@ class TUIApplication:
                 return
             self.last_fleet_refresh = current_time
 
-            if (self.source_type != 'direct'
-                    and self.datasource_manager.is_connected()):
+            if self.source_type == 'direct':
+                self.fleet_cache = self._scan_local_fleet()
+            elif self.datasource_manager.is_connected():
                 devices_dict = self.datasource_manager.list_devices()
                 self.fleet_cache = convert_fleet_format(devices_dict)
             else:
-                self.fleet_cache = self._scan_local_fleet()
+                # A disconnected remote source must not probe local serial
+                # ports, which may already belong to another collector.
+                self.fleet_cache = []
 
             if self.tui_core and self.tui_core.fleet_index >= len(
                     self.fleet_cache):


### PR DESCRIPTION
When a TUI configured for a remote datasource is disconnected, fleet refresh falls back to direct serial discovery. That can probe ports already owned by a collector and lists local devices unrelated to the selected source.

Restrict direct discovery to direct mode. Connected remote sources use their own device lists; disconnected remote sources show an empty fleet. Regression coverage exercises the connected-to-disconnected transition for all seven non-direct source names, including service_ws, and retains direct discovery behavior.

Validation: 31 TUI tests passed on Linux in a real 150x50 terminal. No hardware is required by the new tests.
