### PR TITLE
Display the terminal-size warning before returning from render

### DIFF
--- a/benchlab/tui/test_tui_core.py
+++ b/benchlab/tui/test_tui_core.py
@@ -20,6 +20,7 @@ except ImportError:
     HAS_CURSES = False
 
 import pytest
+from unittest.mock import MagicMock
 
 from benchlab.core.statistics import ChannelStats
 
@@ -239,3 +240,24 @@ def test_help_modal_renders_without_stomping_main_refresh():
         curses.wrapper(_run)
     except curses.error:
         pytest.skip("curses screen unavailable in this environment")
+
+
+@pytest.mark.parametrize("size", [(47, 100), (48, 99), (12, 60)])
+def test_size_warning_is_drawn_and_flushed(monkeypatch, size):
+    from benchlab.tui.tui_core import TUICore
+
+    for name in ("curs_set", "start_color", "use_default_colors", "init_pair"):
+        monkeypatch.setattr(curses, name, MagicMock())
+    monkeypatch.setattr(curses, "color_pair", lambda _: 0)
+    screen = MagicMock()
+    screen.getmaxyx.return_value = size
+    core = TUICore(screen)
+    calls = MagicMock()
+    calls.attach_mock(screen.addstr, "draw")
+    calls.attach_mock(screen.noutrefresh, "stage")
+    monkeypatch.setattr(curses, "doupdate", calls.update)
+
+    assert core.render(_snapshot(), ChannelStats(), [], 1.0) is False
+
+    assert "Terminal too small" in screen.addstr.call_args.args[2]
+    assert [call[0] for call in calls.mock_calls] == ["draw", "stage", "update"]

--- a/benchlab/tui/tui_core.py
+++ b/benchlab/tui/tui_core.py
@@ -82,6 +82,8 @@ class TUICore:
         if (height < Config.MIN_TERMINAL_ROWS
                 or width < Config.MIN_TERMINAL_COLS):
             self._render_size_warning(width, height)
+            self.stdscr.noutrefresh()
+            curses.doupdate()
             return False
 
         # Detect silent resize (windows-curses may not send KEY_RESIZE)


### PR DESCRIPTION
When the terminal is below the supported size, render() draws the resize warning but returns before flushing curses output, leaving the window blank.

Stage and flush the warning before returning. Existing minimum dimensions and layout behavior are preserved. Three headless regression cases verify that the warning is drawn, staged, and flushed in that order, without requiring curses initialization on a real terminal.

Validation: 26 TUI tests passed on Linux in a real 150x50 terminal; the new tests also pass without an attached terminal.
