### PR TITLE
Fix missing dependencies in TUI-only HTTP installations

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -128,3 +128,29 @@ jobs:
 
       - name: Test - link
         run: pytest benchlab/link/test_link_main.py -v
+
+
+  tui-install:
+    name: TUI-only HTTP dependency check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install only the TUI extra in a clean environment
+        run: |
+          python -m venv /tmp/benchlab-tui-check
+          /tmp/benchlab-tui-check/bin/python -m pip install ".[tui]"
+          /tmp/benchlab-tui-check/bin/python -m pip check
+      - name: Check HTTP datasource initialization without hardware or server
+        working-directory: /tmp
+        run: |
+          /tmp/benchlab-tui-check/bin/python - <<'PYTHON'
+          from types import SimpleNamespace
+          from benchlab.tui.tui_main import TUIApplication
+          from benchlab.core.datasource import FastAPIDataSource, ServiceHttpDataSource
+          for source in (FastAPIDataSource(), ServiceHttpDataSource()):
+              assert source._requests is not None, type(source).__name__
+          TUIApplication(SimpleNamespace(source="fastapi_custom", interval=1.0))
+          PYTHON

--- a/benchlab/tui/requirements.txt
+++ b/benchlab/tui/requirements.txt
@@ -1,2 +1,4 @@
 pyserial>=3.5
 windows-curses>=2.4.1; platform_system=="Windows"
+requests>=2.33.1
+pydantic>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,8 @@ dependencies = [
 [project.optional-dependencies]
 tui = [
     "pyserial>=3.5",
+    "pydantic>=2.0.0",
+    "requests>=2.33.1",
 ]
 csv_log = [
     "pyserial>=3.5",


### PR DESCRIPTION
A clean installation of benchlab-pytools[tui] cannot initialize an HTTP-backed TUI: shared datasource configuration imports undeclared pydantic, and HTTP clients require undeclared requests. Installing the server or all dependencies masks these omissions.

Declare both dependencies in the tui extra and TUI requirements file. Add an isolated TUI-only installation job that checks package consistency, initializes both HTTP datasource types, and constructs the TUI application without connecting to hardware or a server.

Validation: built and installed this branch into a fresh environment with only [tui]; FastAPIDataSource, ServiceHttpDataSource, and TUIApplication initialized successfully. Dependency versions align with existing upstream requirements.
