### PR TITLE
Fix collector recovery after incomplete sensor reads

### DIFF
--- a/.github/workflows/pycore-compat.yml
+++ b/.github/workflows/pycore-compat.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Test - REST API server
         run: pytest benchlab/restapi/test_server.py -v -k "not mqtt"
 
+      - name: Test - REST API read recovery
+        run: pytest benchlab/restapi/test_read_recovery.py -v
+
       - name: Test - TUI rendering
         run: pytest benchlab/tui/test_tui_core.py -v -k "not mqtt"
 

--- a/benchlab/restapi/telemetry_api.py
+++ b/benchlab/restapi/telemetry_api.py
@@ -369,29 +369,22 @@ def read_device_loop(port, uid):
     reconnection logic."""
     ser = None
     consecutive_errors = 0
-    max_consecutive_errors = 10  # After this many errors, attempt reconnect
+    max_consecutive_errors = 10  # Back off after repeated read failures
     product_id = None  # Will be set once we read device info
-    is_connected = False  # Track connection status
+    is_connected = False  # Only valid telemetry establishes a connection
+    with data_lock:
+        if uid in devices_data:
+            devices_data[uid]["connected"] = False
+            devices_data[uid]["latest"] = create_empty_telemetry()
 
     while not shutdown_event.is_set():
         # --- (Re)connect ---
         if ser is None:
-            # Mark as disconnected
-            if is_connected:
-                is_connected = False
-                with data_lock:
-                    if uid in devices_data:
-                        devices_data[uid]["connected"] = False
-                        devices_data[uid]["latest"] = create_empty_telemetry()
-                logger.info("[%s] Device disconnected", uid)
-
             try:
                 new_ser = open_serial_connection(port)
                 if new_ser is None:
                     raise OSError("open_serial_connection returned None")
                 ser = new_ser
-                # Reset error counter on successful connect
-                consecutive_errors = 0
 
                 # Read device info to get product_id for sensor reading
                 try:
@@ -408,17 +401,12 @@ def read_device_loop(port, uid):
                 except Exception:
                     pass
 
-                is_connected = True
-                with data_lock:
-                    if uid in devices_data:
-                        devices_data[uid]["connected"] = True
-                logger.info("Connected to device %s on %s", uid, port)
             except Exception as exc:
                 ser = None  # Ensure ser is None on error
                 consecutive_errors += 1
                 delay = min(
                     RECONNECT_DELAY * consecutive_errors,
-                    30)  # Exponential backoff, capped
+                    30)  # Linear backoff, capped
                 logger.warning(
                     "[%s] Failed to open serial port %s: %s (retry in %.1fs)",
                     uid,
@@ -435,6 +423,8 @@ def read_device_loop(port, uid):
                 shutdown_event.wait(1)
                 continue
             sensors = read_sensors(ser, product_id=product_id)
+            if sensors is None:
+                raise OSError("No complete sensor response received")
             if sensors:
                 translated = translate_sensor_struct(sensors)
                 translated["timestamp"] = datetime.now().strftime(
@@ -444,12 +434,14 @@ def read_device_loop(port, uid):
 
                 with data_lock:
                     if uid in devices_data:
+                        devices_data[uid]["connected"] = True
                         devices_data[uid]["latest"] = translated
                         devices_data[uid]["history"].append(translated)
 
+                if not is_connected:
+                    is_connected = True
+                    logger.info("Connected to device %s on %s", uid, port)
                 schedule_update(uid, translated)
-            else:
-                logger.debug("[%s] No sensor data read", uid)
         except Exception as e:
             consecutive_errors += 1
             # Specific debug logging for unsupported commands
@@ -473,8 +465,15 @@ def read_device_loop(port, uid):
             except Exception:
                 pass
             ser = None
+            if is_connected:
+                logger.info("[%s] Device disconnected", uid)
+            is_connected = False
+            with data_lock:
+                if uid in devices_data:
+                    devices_data[uid]["connected"] = False
+                    devices_data[uid]["latest"] = create_empty_telemetry()
 
-            # Exponential backoff with cap
+            # Linear backoff with cap
             if consecutive_errors >= max_consecutive_errors:
                 delay = min(RECONNECT_DELAY * consecutive_errors, 30)
                 logger.warning(

--- a/benchlab/restapi/test_read_recovery.py
+++ b/benchlab/restapi/test_read_recovery.py
@@ -1,0 +1,139 @@
+"""Fault injection for the collector's serial recovery; no hardware needed."""
+from collections import deque
+from unittest.mock import MagicMock
+
+import pytest
+
+from benchlab.restapi import telemetry_api as api
+
+
+class StopEvent:
+    def __init__(self):
+        self.stopped = False
+        self.waits = []
+        self.on_wait = lambda _: None
+
+    def is_set(self):
+        return self.stopped
+
+    def wait(self, delay):
+        self.waits.append(delay)
+        self.on_wait(delay)
+        return self.stopped
+
+
+@pytest.fixture
+def reader(monkeypatch):
+    stop = StopEvent()
+    device = {"connected": False, "latest": {}, "history": deque()}
+    connections = []
+
+    def open_port(_):
+        ser = MagicMock()
+        connections.append(ser)
+        if len(connections) > 30:
+            stop.stopped = True  # Bound regressions that never reach backoff.
+        return ser
+
+    monkeypatch.setattr(api, "shutdown_event", stop)
+    monkeypatch.setattr(api, "devices_data", {"test": device})
+    monkeypatch.setattr(api, "open_serial_connection", open_port)
+    monkeypatch.setattr(api, "read_device", lambda _: {"ProductId": 16})
+    monkeypatch.setattr(api, "translate_sensor_struct", lambda _: {"TS_2": 24.0})
+    publish = MagicMock()
+    monkeypatch.setattr(api, "schedule_update", publish)
+    return stop, device, connections, publish
+
+
+@pytest.mark.parametrize("failure", [None, OSError("USB disconnected")])
+def test_failed_read_discards_stale_data_and_reconnects(monkeypatch, reader, failure):
+    stop, device, connections, publish = reader
+    reads = 0
+
+    def read(*args, **kwargs):
+        nonlocal reads
+        reads += 1
+        if reads == 2:
+            assert device["connected"]
+            if isinstance(failure, Exception):
+                raise failure
+            return failure
+        if reads == 3:
+            assert not device["connected"]
+            assert device["latest"]["connected"] is False
+            assert len(connections) == 2
+            stop.stopped = True
+        return object()
+
+    monkeypatch.setattr(api, "read_sensors", read)
+    api.read_device_loop("/fake", "test")
+    assert publish.call_count == 2
+    assert len(device["history"]) == 2
+    assert all(s.close.call_count == 1 for s in connections)
+
+
+@pytest.mark.parametrize("failure", [None, OSError("read failed")])
+def test_repeated_read_failures_back_off_even_when_open_succeeds(monkeypatch, reader, failure):
+    stop, device, connections, publish = reader
+
+    def read(*args, **kwargs):
+        assert not device["connected"]
+        if isinstance(failure, Exception):
+            raise failure
+        return failure
+
+    def waited(delay):
+        assert not device["connected"]
+        assert device["latest"]["connected"] is False
+        stop.stopped = True
+
+    stop.on_wait = waited
+    monkeypatch.setattr(api, "read_sensors", read)
+    api.read_device_loop("/fake", "test")
+    assert len(connections) == 10
+    assert stop.waits == [min(api.RECONNECT_DELAY * 10, 30)]
+    publish.assert_not_called()
+    assert not device["history"]
+    assert all(s.close.call_count == 1 for s in connections)
+
+
+def test_valid_sample_resets_failure_streak(monkeypatch, reader):
+    stop, device, connections, publish = reader
+    reads = 0
+
+    def read(*args, **kwargs):
+        nonlocal reads
+        reads += 1
+        if reads == 10:
+            return object()
+        return None
+
+    def waited(delay):
+        if delay == api.poll_interval:
+            assert device["connected"]
+        else:
+            assert reads == 20
+            stop.stopped = True
+
+    stop.on_wait = waited
+    monkeypatch.setattr(api, "read_sensors", read)
+    api.read_device_loop("/fake", "test")
+    assert stop.waits == [api.poll_interval, min(api.RECONNECT_DELAY * 10, 30)]
+    publish.assert_called_once()
+    assert len(device["history"]) == 1
+
+
+def test_failed_initial_open_clears_discovery_connected_flag(monkeypatch, reader):
+    stop, device, connections, publish = reader
+    device.update(connected=True, latest={"TS_2": 24.0})
+    monkeypatch.setattr(api, "open_serial_connection", lambda _: None)
+
+    def waited(delay):
+        assert not device["connected"]
+        assert device["latest"]["connected"] is False
+        stop.stopped = True
+
+    stop.on_wait = waited
+    api.read_device_loop("/fake", "test")
+    assert stop.waits == [min(api.RECONNECT_DELAY, 30)]
+    publish.assert_not_called()


### PR DESCRIPTION
Incomplete sensor responses return `None`, but the collector currently keeps publishing its previous connection state and never reconnects for that failure. Repeated read exceptions also lose their failure count whenever the serial port reopens, so the intended read-error backoff is never reached.

Treat incomplete responses as read failures, clear stale telemetry before waiting, and mark a device connected only after a successfully decoded sample. Keep the failure count across port reopen attempts and reset it after valid telemetry. This restores the existing retry policy without adding fan-control behavior or changing device configuration.

Adds six fault-injection cases covering empty reads, exceptions, stale state, repeated failures, recovery after a valid sample, and failed initial opens. Wires them into the existing Windows/Linux, pinned/latest-pycore CI matrix.

Validation: `python -m pytest -q -m 'not integration'` — 199 passed, 24 skipped, 42 deselected. Hardware-dependent integration tests were not run against this patch; the live collector has not been replaced.
